### PR TITLE
#881: Sets executionContext for Futures.

### DIFF
--- a/src/main/scala/no/ndla/draftapi/controller/InternController.scala
+++ b/src/main/scala/no/ndla/draftapi/controller/InternController.scala
@@ -8,7 +8,7 @@
 
 package no.ndla.draftapi.controller
 
-import java.util.concurrent.TimeUnit
+import java.util.concurrent.{Executors, TimeUnit}
 
 import no.ndla.draftapi.auth.Role
 import no.ndla.draftapi.model.api.ContentId
@@ -19,7 +19,6 @@ import no.ndla.draftapi.service.search.{AgreementIndexService, ArticleIndexServi
 import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.{InternalServerError, NotFound, Ok}
 
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
 import scala.concurrent.duration.Duration
 import scala.util.{Failure, Success}
@@ -41,6 +40,7 @@ trait InternController {
     protected implicit override val jsonFormats: Formats = DefaultFormats
 
     post("/index") {
+      implicit val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor)
       val indexResults = for {
         articleIndex <- Future { articleIndexService.indexDocuments }
         conceptIndex <- Future { conceptIndexService.indexDocuments }

--- a/src/main/scala/no/ndla/draftapi/service/search/IndexService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/search/IndexService.scala
@@ -10,6 +10,7 @@ package no.ndla.draftapi.service.search
 
 import java.text.SimpleDateFormat
 import java.util.Calendar
+
 import com.sksamuel.elastic4s.http.ElasticDsl._
 import com.sksamuel.elastic4s.indexes.IndexDefinition
 import com.sksamuel.elastic4s.mappings.MappingDefinition
@@ -18,6 +19,7 @@ import no.ndla.draftapi._
 import no.ndla.draftapi.integration.Elastic4sClient
 import no.ndla.draftapi.model.domain.{Content, ReindexResult}
 import no.ndla.draftapi.repository.Repository
+
 import scala.util.{Failure, Success, Try}
 
 trait IndexService {


### PR DESCRIPTION
Gets executioncontext from executorservice in multiple places so that we may spawn as many
threads as we please rather than being limited by the global setting
(one per cpucore)