### PR TITLE
migration script for converting h5 and h5 html tags #1396

### DIFF
--- a/src/main/scala/db/migration/V11__ConvertH5AndH6ToH3.scala
+++ b/src/main/scala/db/migration/V11__ConvertH5AndH6ToH3.scala
@@ -1,0 +1,117 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2018 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s.JsonAST.{JInt, JString}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.json4s.{DefaultFormats, JArray, JObject}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+import scala.collection.JavaConverters._
+
+class V11__ConvertH5AndH6ToH3 extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateArticles
+    }
+  }
+
+  private def migrateArticles(implicit session: DBSession): Unit = {
+    val count = countAllArticles.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allArticles(offset * 1000).map {
+        case (id, document) => updateArticle(convertArticleUpdate(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  private def countAllArticles(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from articledata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+      .apply()
+  }
+
+  private def allArticles(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document from articledata where document is not null order by id limit 1000 offset ${offset}"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list
+      .apply()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  private def jsoupDocumentToString(element: Element): String = {
+    element.select("body").html()
+  }
+
+  private def removeH5AndH6(html: String): String = {
+    val doc = stringToJsoupDocument(html)
+    doc
+      .select("h5,h6")
+      .asScala
+      .foreach(tag => {
+        tag.tagName match {
+          case "h5" => tag.tagName("strong").wrap("<p></p>")
+          case "h6" => tag.unwrap()
+        }
+      })
+    jsoupDocumentToString(doc)
+  }
+
+  private[migration] def convertArticleUpdate(document: String): String = {
+    val oldArticle = parse(document)
+
+    val newArticle = oldArticle.mapField {
+      case ("content", contents: JArray) =>
+        val updatedContent = contents.map {
+          case content: JObject =>
+            content.mapField {
+              case ("content", JString(html)) => ("content", JString(removeH5AndH6(html)))
+              case z                          => z
+            }
+          case y => y
+        }
+        ("content", updatedContent)
+      case x => x
+    }
+
+    compact(render(newArticle))
+  }
+
+  private def updateArticle(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update articledata set document = ${dataObject} where id = ${id}"
+      .update()
+      .apply
+  }
+
+}

--- a/src/test/scala/db/migration/V11__ConvertH5AndH6ToH3Test.scala
+++ b/src/test/scala/db/migration/V11__ConvertH5AndH6ToH3Test.scala
@@ -1,0 +1,30 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2018 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import no.ndla.draftapi.{TestEnvironment, UnitSuite}
+
+class V11__ConvertH5AndH6ToH3Test extends UnitSuite with TestEnvironment {
+
+  val migration = new V11__ConvertH5AndH6ToH3
+
+  test("migration should convert h5 and h6 html tags to h3") {
+    val old =
+      s"""{"content":[{"content":"<section><h5>hi</h5></section>","language":"nb"},{"content":"<section><h6>hi</h6></section>","language":"nn"}],"title":[{"title":"tittel","language":"nb"}]}"""
+    val expected =
+      s"""{"content":[{"content":"<section><p><strong>hi</strong></p></section>","language":"nb"},{"content":"<section>hi</section>","language":"nn"}],"title":[{"title":"tittel","language":"nb"}]}"""
+    migration.convertArticleUpdate(old) should equal(expected)
+  }
+
+  test("migration should not convert any other tags") {
+    val original =
+      s"""{"content":[{"content":"<section><h3>hi</h3></section>","language":"nb"},{"content":"<section><h3>hi</h3><p>heh</p></section>","language":"nn"}],"title":[{"title":"tittel","language":"nb"}]}"""
+    migration.convertArticleUpdate(original) should equal(original)
+  }
+
+}


### PR DESCRIPTION
resolves NDLANO/Issues#1396

Er i utgangspunktet skeptisk til å kjøre migreringer på html-innhold fordi det potensielt kan ta veldig lang tid. Kopierte test-database lokalt og prøvde å kjøre migrering på den. Tok i alt ~12.5 sekunder på >10k artikler, så jeg *håper* det går bra remote også