### PR TITLE
Remove set-to-publish and rename admin to publish.

### DIFF
--- a/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -23,7 +23,7 @@ object DraftApiProperties extends LazyLogging {
   val ApplicationName = "draft-api"
   val Auth0LoginEndpoint = s"https://${AuthUser.getAuth0HostForEnv(Environment)}/authorize"
   val DraftRoleWithWriteAccess = "drafts:write"
-  val DraftRoleWithPublishAccess = "drafts:set_to_publish"
+  val DraftRoleWithPublishAccess = "drafts:publish"
   val ArticleRoleWithPublishAccess = "articles:publish"
 
   val ApplicationPort = propOrElse("APPLICATION_PORT", "80").toInt

--- a/src/main/scala/no/ndla/draftapi/auth/Role.scala
+++ b/src/main/scala/no/ndla/draftapi/auth/Role.scala
@@ -8,7 +8,7 @@
 package no.ndla.draftapi.auth
 
 object Role extends Enumeration {
-  val WRITE, SET_TO_PUBLISH, ADMIN = Value
+  val WRITE, PUBLISH = Value
 
   def valueOf(s: String): Option[Role.Value] = {
     val role = s.split("drafts:")

--- a/src/main/scala/no/ndla/draftapi/auth/UserInfo.scala
+++ b/src/main/scala/no/ndla/draftapi/auth/UserInfo.scala
@@ -10,8 +10,7 @@ package no.ndla.draftapi.auth
 import no.ndla.network.AuthUser
 
 case class UserInfo(id: String, roles: Set[Role.Value]) {
-  def isAdmin: Boolean = hasRoles(UserInfo.AdminRoles)
-  def canSetPublish: Boolean = hasRoles(UserInfo.SetPublishRoles)
+  def canPublish: Boolean = hasRoles(UserInfo.PublishRoles)
   def canWrite: Boolean = hasRoles(UserInfo.WriteRoles)
   def canRead: Boolean = hasRoles(UserInfo.ReadRoles)
 
@@ -21,8 +20,7 @@ case class UserInfo(id: String, roles: Set[Role.Value]) {
 object UserInfo {
   val UnauthorizedUser = UserInfo("unauthorized", Set.empty)
 
-  val AdminRoles = Set(Role.ADMIN)
-  val SetPublishRoles = Set(Role.WRITE, Role.SET_TO_PUBLISH)
+  val PublishRoles = Set(Role.WRITE, Role.PUBLISH)
   val WriteRoles = Set(Role.WRITE)
   val ReadRoles = Set(Role.WRITE)
 

--- a/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -593,7 +593,7 @@ trait ConverterService {
       StateTransitionRules.StateTransitions.groupBy(_.from).map {
         case (from, to) =>
           from.toString -> to
-            .filter(t => user.hasRoles(t.requiredRoles) || user.isAdmin) // filter out transitions which require admin if user is not admin
+            .filter(t => user.hasRoles(t.requiredRoles))
             .map(_.to.toString)
             .toSeq
       }

--- a/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -33,8 +33,7 @@ object TestData {
 
   val userWithNoRoles = UserInfo("unit test", Set.empty)
   val userWithWriteAccess = UserInfo("unit test", Set(Role.WRITE))
-  val userWithPublishAccess = UserInfo("unit test", Set(Role.WRITE, Role.SET_TO_PUBLISH))
-  val userWIthAdminAccess = UserInfo("unit test", Set(Role.WRITE, Role.SET_TO_PUBLISH, Role.ADMIN))
+  val userWithPublishAccess = UserInfo("unit test", Set(Role.WRITE, Role.PUBLISH))
 
   private val publicDomainCopyright =
     Copyright(Some("publicdomain"), Some(""), List.empty, List(), List(), None, None, None)

--- a/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -154,22 +154,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     res(UNPUBLISHED.toString).length should be(2)
   }
 
-  test("stateTransitionsToApi should return only certain entries if user only has set_to_publish") {
-    val res = service.stateTransitionsToApi(TestData.userWithPublishAccess)
-    res(IMPORTED.toString).length should be(1)
-    res(DRAFT.toString).length should be(2)
-    res(PROPOSAL.toString).length should be(6)
-    res(USER_TEST.toString).length should be(4)
-    res(AWAITING_QUALITY_ASSURANCE.toString).length should be(5)
-    res(QUALITY_ASSURED.toString).length should be(3)
-    res(QUEUED_FOR_PUBLISHING.toString).length should be(2)
-    res(PUBLISHED.toString).length should be(3)
-    res(AWAITING_UNPUBLISHING.toString).length should be(2)
-    res(UNPUBLISHED.toString).length should be(2)
-  }
-
   test("stateTransitionsToApi should return all entries if user is admin") {
-    val res = service.stateTransitionsToApi(TestData.userWIthAdminAccess)
+    val res = service.stateTransitionsToApi(TestData.userWithPublishAccess)
     res(IMPORTED.toString).length should be(1)
     res(DRAFT.toString).length should be(4)
     res(PROPOSAL.toString).length should be(8)
@@ -419,7 +405,7 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     val status = Status(ArticleStatus.DRAFT, other = Set(ArticleStatus.PUBLISHED))
     val article = TestData.sampleDomainArticle.copy(status = status)
     val Failure(res: IllegalStatusStateTransition) =
-      service.updateStatus(ARCHIVED, article, TestData.userWIthAdminAccess, isImported = false).unsafeRunSync()
+      service.updateStatus(ARCHIVED, article, TestData.userWithPublishAccess, isImported = false).unsafeRunSync()
 
     res.getMessage should equal(s"Cannot go to ARCHIVED when article contains ${status.other}")
   }

--- a/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/StateTransitionRulesTest.scala
@@ -38,7 +38,8 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
 
   test("doTransition should succeed when performing a legal transition") {
     val expected = domain.Status(PUBLISHED, Set.empty)
-    val (Success(res), _) = doTransitionWithoutSideEffect(DraftArticle, PUBLISHED, TestData.userWIthAdminAccess, false)
+    val (Success(res), _) =
+      doTransitionWithoutSideEffect(DraftArticle, PUBLISHED, TestData.userWithPublishAccess, false)
 
     res.status should equal(expected)
   }
@@ -48,7 +49,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val (Success(res), _) =
       doTransitionWithoutSideEffect(DraftArticle.copy(status = UserTestStatus),
                                     USER_TEST,
-                                    TestData.userWIthAdminAccess,
+                                    TestData.userWithPublishAccess,
                                     false)
     res.status should equal(expected)
 
@@ -56,7 +57,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val (Success(res2), _) =
       doTransitionWithoutSideEffect(DraftArticle.copy(status = PublishedStatus),
                                     DRAFT,
-                                    TestData.userWIthAdminAccess,
+                                    TestData.userWithPublishAccess,
                                     false)
     res2.status should equal(expected2)
 
@@ -64,13 +65,13 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val (Success(res3), _) =
       doTransitionWithoutSideEffect(DraftArticle.copy(status = DraftWithPublishedStatus),
                                     DRAFT,
-                                    TestData.userWIthAdminAccess,
+                                    TestData.userWithPublishAccess,
                                     false)
     res3.status should equal(expected3)
   }
 
   test("doTransition should fail when performing an illegal transition") {
-    val (res, _) = doTransitionWithoutSideEffect(DraftArticle, QUALITY_ASSURED, TestData.userWIthAdminAccess, false)
+    val (res, _) = doTransitionWithoutSideEffect(DraftArticle, QUALITY_ASSURED, TestData.userWithPublishAccess, false)
     res.isFailure should be(true)
   }
 
@@ -83,7 +84,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
       .thenReturn(Success(expectedArticle))
 
     val (Success(res), sideEffect) =
-      doTransitionWithoutSideEffect(DraftArticle, PUBLISHED, TestData.userWIthAdminAccess, false)
+      doTransitionWithoutSideEffect(DraftArticle, PUBLISHED, TestData.userWithPublishAccess, false)
     sideEffect(res).get.status should equal(expectedStatus)
 
     val captor = ArgumentCaptor.forClass(classOf[Article])
@@ -106,7 +107,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(articleApiClient.unpublishArticle(any[Article])).thenReturn(Success(expectedArticle))
 
     val (Success(res), sideEffect) =
-      doTransitionWithoutSideEffect(AwaitingUnpublishArticle, UNPUBLISHED, TestData.userWIthAdminAccess, false)
+      doTransitionWithoutSideEffect(AwaitingUnpublishArticle, UNPUBLISHED, TestData.userWithPublishAccess, false)
     sideEffect(res).get.status should equal(expectedStatus)
 
     val captor = ArgumentCaptor.forClass(classOf[Article])
@@ -125,7 +126,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     when(articleIndexService.deleteDocument(UnpublishedArticle.id.get)).thenReturn(Success(UnpublishedArticle.id.get))
 
     val (Success(res), sideEffect) =
-      doTransitionWithoutSideEffect(UnpublishedArticle, ARCHIVED, TestData.userWIthAdminAccess, false)
+      doTransitionWithoutSideEffect(UnpublishedArticle, ARCHIVED, TestData.userWithPublishAccess, false)
     sideEffect(res).get.status should equal(expectedStatus)
 
     verify(articleIndexService, times(1))
@@ -147,7 +148,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
     val expected = domain.Status(UNPUBLISHED, Set())
     val publishedArticle = DraftArticle.copy(status = domain.Status(current = PUBLISHED, other = Set()))
     val (Success(res), _) =
-      doTransitionWithoutSideEffect(publishedArticle, UNPUBLISHED, TestData.userWIthAdminAccess, false)
+      doTransitionWithoutSideEffect(publishedArticle, UNPUBLISHED, TestData.userWithPublishAccess, false)
 
     res.status should equal(expected)
   }
@@ -239,7 +240,7 @@ class StateTransitionRulesTest extends UnitSuite with TestEnvironment {
         StateTransitionRules
           .doTransition(article.copy(status = status.copy(current = t.from)),
                         QUEUED_FOR_PUBLISHING,
-                        TestData.userWIthAdminAccess,
+                        TestData.userWithPublishAccess,
                         false)
           .unsafeRunSync())
     verify(contentValidator, times(transitionsToTest.size)).validateArticle(any[domain.Article], any[Boolean])

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -499,7 +499,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       )
 
     when(draftRepository.withId(anyLong())).thenReturn(Some(article))
-    service.updateArticle(1, updatedArticle, List(), List(), TestData.userWIthAdminAccess, None, None, None)
+    service.updateArticle(1, updatedArticle, List(), List(), TestData.userWithPublishAccess, None, None, None)
 
     val argCap: ArgumentCaptor[Article] = ArgumentCaptor.forClass(classOf[Article])
     verify(contentValidator, times(1)).validateArticle(argCap.capture(), any[Boolean])


### PR DESCRIPTION
NDLA ønsker enklere roller. Treng ikkje skille på set_to_publish og publish.
I tillegg ønskes en rolle draft:html for å styre tilgang til html-editor, men denne treng ikkje draft-api å vite om.