### PR TITLE
Allow unknown as language

### DIFF
--- a/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -190,7 +190,7 @@ trait StateTransitionRules {
       articleIndexService.deleteDocument(article.id.get).map(_ => article)
 
     private def validateArticle(article: domain.Article): Try[domain.Article] =
-      contentValidator.validateArticle(article, false)
+      contentValidator.validateArticle(article, true)
 
   }
 }


### PR DESCRIPTION
Mange artikler i ff kan ikkje publiseres fordi dei kun har unknown som språk. Disse må kunne slippe gjennom.