### PR TITLE
#2130: Clone files when saving existing files as new language

### DIFF
--- a/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
+++ b/src/main/scala/no/ndla/draftapi/repository/DraftRepository.scala
@@ -27,8 +27,7 @@ trait DraftRepository {
   val draftRepository: ArticleRepository
 
   class ArticleRepository extends LazyLogging with Repository[Article] {
-    implicit val formats = org.json4s.DefaultFormats + Article.JSonSerializer + new EnumNameSerializer(ArticleStatus) + new EnumNameSerializer(
-      ArticleType)
+    implicit val formats = Article.repositorySerializer
 
     def insert(article: Article)(implicit session: DBSession = AutoSession): Article = {
       val startRevision = article.revision.getOrElse(1)

--- a/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -597,13 +597,5 @@ trait ConverterService {
       api.TagsSearchResult(tagsCount, offset, pageSize, language, tags)
     }
 
-    def getFilePathsInArticleContents(content: ArticleContent): Set[String] = {
-      val contentDoc = HtmlTagRules.stringToJsoupDocument(content.content)
-      contentDoc
-        .select(s"embed[${TagAttributes.DataResource}='${ResourceType.File}']")
-        .asScala
-        .flatMap(e => Option(e.attr(TagAttributes.DataPath.toString)))
-    }.toSet
-
   }
 }

--- a/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -597,16 +597,13 @@ trait ConverterService {
       api.TagsSearchResult(tagsCount, offset, pageSize, language, tags)
     }
 
-    def getFilePathsInArticleContents(contents: Seq[ArticleContent]): Set[String] =
-      contents
-        .flatMap(content => {
-          val contentDoc = HtmlTagRules.stringToJsoupDocument(content.content)
-          contentDoc
-            .select(s"embed[${TagAttributes.DataResource}='${ResourceType.File}']")
-            .asScala
-            .flatMap(e => Option(e.attr(TagAttributes.DataPath.toString)))
-        })
-        .toSet
+    def getFilePathsInArticleContents(content: ArticleContent): Set[String] = {
+      val contentDoc = HtmlTagRules.stringToJsoupDocument(content.content)
+      contentDoc
+        .select(s"embed[${TagAttributes.DataResource}='${ResourceType.File}']")
+        .asScala
+        .flatMap(e => Option(e.attr(TagAttributes.DataPath.toString)))
+    }.toSet
 
   }
 }

--- a/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -101,7 +101,8 @@ trait WriteService {
       })
     }
 
-    def cloneEmbedAndUpdateElement(fileEmbed: Element): Try[_] = {
+    /** MUTATES fileEmbed by cloning file and updating data-path */
+    def cloneEmbedAndUpdateElement(fileEmbed: Element): Try[Element] = {
       Option(fileEmbed.attr(TagAttributes.DataPath.toString)) match {
         case Some(existingPath) =>
           cloneFileAndGetNewPath(existingPath).map(newPath => {

--- a/src/test/scala/no/ndla/draftapi/integration/ArticleApiClientTest.scala
+++ b/src/test/scala/no/ndla/draftapi/integration/ArticleApiClientTest.scala
@@ -70,7 +70,7 @@ class ArticleApiClientTest extends IntegrationSuite with TestEnvironment {
   val authHeaderMap = Map("Authorization" -> s"Bearer $exampleToken")
 
   test("that updating articles should work") {
-    implicit val formats: Formats = domain.Article.formats
+    implicit val formats: Formats = domain.Article.jsonEncoder
 
     forgePact
       .between("draft-api")


### PR DESCRIPTION
Fixes NDLANO/Issues#2130

Fikser også at kloning av artikler med filer får en kopi pr embed, istedet for å gjenbruke på tvers av språkversjoner som tidligere.