### PR TITLE
removed extra / from h5p data-url

### DIFF
--- a/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -92,10 +92,10 @@ object DraftApiProperties extends LazyLogging {
   lazy val H5PAddress = propOrElse(
     "NDLA_H5P_ADDRESS",
     Map(
-      "test" -> "https://h5p-test.ndla.no/",
-      "staging" -> "https://h5p-staging.ndla.no/",
-      "ff" -> "https://h5p-ff.ndla.no/"
-    ).getOrElse(Environment, "https://h5p.ndla.no/")
+      "test" -> "https://h5p-test.ndla.no",
+      "staging" -> "https://h5p-staging.ndla.no",
+      "ff" -> "https://h5p-ff.ndla.no"
+    ).getOrElse(Environment, "https://h5p.ndla.no")
   )
 
   lazy val Domain = Domains.get(Environment)

--- a/src/test/scala/no/ndla/draftapi/service/ReadServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/ReadServiceTest.scala
@@ -118,7 +118,7 @@ class ReadServiceTest extends UnitSuite with TestEnvironment {
     val content =
       s"""<div><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p"></div>"""
     val expectedResult =
-      s"""<div><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no/$h5pPath"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no/$h5pPath"></div>"""
+      s"""<div><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath"><$resourceHtmlEmbedTag $resourceAttr="${ResourceType.H5P}" ${TagAttributes.DataPath}="$h5pPath" ${TagAttributes.Title}="This fancy h5p" $urlAttr="https://h5p.ndla.no$h5pPath"></div>"""
     val result = readService.addUrlOnResource(content)
     result should equal(expectedResult)
   }


### PR DESCRIPTION
https://github.com/NDLANO/Issues/issues/2146

Extra `/` fix, from
```
data-url="https://h5p-test.ndla.no//resource/ea9bd951-c422-4a64-b057-1bb0075e5b76"
```
to
```
data-url="https://h5p-test.ndla.no/resource/ea9bd951-c422-4a64-b057-1bb0075e5b76"
```