### PR TITLE
#2226: Only create initial scroll-context when provided with '0', 'start', 'first' or 'initial'

### DIFF
--- a/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
+++ b/src/main/scala/no/ndla/draftapi/DraftApiProperties.scala
@@ -83,7 +83,8 @@ object DraftApiProperties extends LazyLogging {
   val MaxPageSize = 10000
   val IndexBulkSize = 200
   val ElasticSearchIndexMaxResultWindow = 10000
-  val ElasticSearchScrollKeepAlive = "10s"
+  val ElasticSearchScrollKeepAlive = "1m"
+  val InitialScrollContextKeywords = List("0", "initial", "start", "first")
 
   val CorrelationIdKey = "correlationID"
   val CorrelationIdHeader = "X-Correlation-ID"

--- a/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -8,6 +8,7 @@
 package no.ndla.draftapi.controller
 
 import no.ndla.draftapi.DraftApiProperties
+import no.ndla.draftapi.DraftApiProperties.InitialScrollContextKeywords
 import no.ndla.draftapi.auth.User
 import no.ndla.draftapi.model.api._
 import no.ndla.draftapi.model.domain
@@ -164,7 +165,8 @@ trait DraftController {
                        idList: List[Long],
                        articleTypesFilter: Seq[String],
                        fallback: Boolean,
-                       grepCodes: Seq[String]) = {
+                       grepCodes: Seq[String],
+                       shouldScroll: Boolean) = {
       val searchSettings = query match {
         case Some(q) =>
           SearchSettings(
@@ -177,7 +179,8 @@ trait DraftController {
             sort = sort.getOrElse(Sort.ByRelevanceDesc),
             if (articleTypesFilter.isEmpty) ArticleType.all else articleTypesFilter,
             fallback = fallback,
-            grepCodes = grepCodes
+            grepCodes = grepCodes,
+            shouldScroll = shouldScroll
           )
         case None =>
           SearchSettings(
@@ -190,7 +193,8 @@ trait DraftController {
             sort = sort.getOrElse(Sort.ByTitleAsc),
             if (articleTypesFilter.isEmpty) ArticleType.all else articleTypesFilter,
             fallback = fallback,
-            grepCodes = grepCodes
+            grepCodes = grepCodes,
+            shouldScroll = shouldScroll
           )
       }
 
@@ -272,8 +276,21 @@ trait DraftController {
           val articleTypesFilter = paramAsListOfString(this.articleTypes.paramName)
           val fallback = booleanOrDefault(this.fallback.paramName, default = false)
           val grepCodes = paramAsListOfString(this.grepCodes.paramName)
+          val shouldScroll = paramOrNone(this.scrollId.paramName).exists(InitialScrollContextKeywords.contains)
 
-          search(query, sort, language, license, page, pageSize, idList, articleTypesFilter, fallback, grepCodes)
+          search(
+            query,
+            sort,
+            language,
+            license,
+            page,
+            pageSize,
+            idList,
+            articleTypesFilter,
+            fallback,
+            grepCodes,
+            shouldScroll
+          )
         }
       }
     }
@@ -308,8 +325,21 @@ trait DraftController {
               val articleTypesFilter = searchParams.articleTypes
               val fallback = searchParams.fallback.getOrElse(false)
               val grepCodes = searchParams.grepCodes
+              val shouldScroll = searchParams.scrollId.exists(InitialScrollContextKeywords.contains)
 
-              search(query, sort, language, license, page, pageSize, idList, articleTypesFilter, fallback, grepCodes)
+              search(
+                query,
+                sort,
+                language,
+                license,
+                page,
+                pageSize,
+                idList,
+                articleTypesFilter,
+                fallback,
+                grepCodes,
+                shouldScroll
+              )
             }
           case Failure(ex) => errorHandler(ex)
         }

--- a/src/main/scala/no/ndla/draftapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/draftapi/controller/NdlaController.scala
@@ -14,7 +14,8 @@ import no.ndla.draftapi.DraftApiProperties.{
   CorrelationIdHeader,
   CorrelationIdKey,
   ElasticSearchIndexMaxResultWindow,
-  ElasticSearchScrollKeepAlive
+  ElasticSearchScrollKeepAlive,
+  InitialScrollContextKeywords
 }
 import no.ndla.draftapi.model.api.{
   AccessDeniedException,
@@ -114,12 +115,12 @@ abstract class NdlaController extends ScalatraServlet with NativeJsonSupport wit
   protected val fallback = Param[Option[Boolean]]("fallback", "Fallback to existing language if language is specified.")
   protected val scrollId = Param[Option[String]](
     "search-context",
-    s"""A search context retrieved from the response header of a previous search.
-       |If search-context is specified, all other query parameters, except '${this.language.paramName}' and '${this.fallback.paramName}' are ignored
-       |For the rest of the parameters the original search of the search-context is used.
-       |The search context may change between scrolls. Always use the most recent one (The context if unused dies after $ElasticSearchScrollKeepAlive).
-       |Used to enable scrolling past $ElasticSearchIndexMaxResultWindow results.
-      """.stripMargin
+    s"""A unique string obtained from a search you want to keep scrolling in. To obtain one from a search, provide one of the following values: ${InitialScrollContextKeywords
+         .mkString("[", ",", "]")}.
+       |When scrolling, the parameters from the initial search is used, except in the case of '${this.language.paramName}' and '${this.fallback.paramName}'.
+       |This value may change between scrolls. Always use the one in the latest scroll result (The context, if unused, dies after $ElasticSearchScrollKeepAlive).
+       |If you are not paginating past $ElasticSearchIndexMaxResultWindow hits, you can ignore this and use '${this.pageNo.paramName}' and '${this.pageSize.paramName}' instead.
+       |""".stripMargin
   )
 
   protected def asQueryParam[T: Manifest: NotNothing](param: Param[T]) =

--- a/src/main/scala/no/ndla/draftapi/model/domain/AgreementSearchSettings.scala
+++ b/src/main/scala/no/ndla/draftapi/model/domain/AgreementSearchSettings.scala
@@ -1,15 +1,11 @@
 package no.ndla.draftapi.model.domain
 
-case class SearchSettings(
+case class AgreementSearchSettings(
     query: Option[String],
     withIdIn: List[Long],
-    searchLanguage: String,
     license: Option[String],
     page: Int,
     pageSize: Int,
     sort: Sort.Value,
-    articleTypes: Seq[String],
-    fallback: Boolean,
-    grepCodes: Seq[String],
     shouldScroll: Boolean
 )

--- a/src/main/scala/no/ndla/draftapi/model/domain/SearchSettings.scala
+++ b/src/main/scala/no/ndla/draftapi/model/domain/SearchSettings.scala
@@ -1,0 +1,14 @@
+package no.ndla.draftapi.model.domain
+
+case class SearchSettings(
+    query: Option[String],
+    withIdIn: List[Long],
+    searchLanguage: String,
+    license: Option[String],
+    page: Int,
+    pageSize: Int,
+    sort: Sort.Value,
+    articleTypes: Seq[String],
+    fallback: Boolean,
+    grepCodes: Seq[String]
+)

--- a/src/main/scala/no/ndla/draftapi/service/search/AgreementSearchService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/search/AgreementSearchService.scala
@@ -59,9 +59,12 @@ trait AgreementSearchService {
                       queryBuilder: BoolQuery): Try[SearchResult[api.AgreementSummary]] = {
       val idFilter = if (settings.withIdIn.isEmpty) None else Some(idsQuery(settings.withIdIn))
 
-      // TODO: License filter?
+      val licenseFilter = settings.license match {
+        case None      => None
+        case Some(lic) => Some(termQuery("license", lic))
+      }
 
-      val filters = List(idFilter)
+      val filters = List(idFilter, licenseFilter)
       val filteredSearch = queryBuilder.filter(filters.flatten)
 
       val (startAt, numResults) = getStartAtAndNumResults(settings.page, settings.pageSize)

--- a/src/main/scala/no/ndla/draftapi/service/search/AgreementSearchService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/search/AgreementSearchService.scala
@@ -38,45 +38,34 @@ trait AgreementSearchService {
       searchConverterService.hitAsAgreementSummary(hit)
     }
 
-    def all(withIdIn: List[Long],
-            license: Option[String],
-            page: Int,
-            pageSize: Int,
-            sort: Sort.Value): Try[SearchResult[api.AgreementSummary]] = {
-      executeSearch(withIdIn, license, sort, page, pageSize, boolQuery())
-    }
+    def matchingQuery(settings: AgreementSearchSettings): Try[SearchResult[api.AgreementSummary]] = {
 
-    def matchingQuery(query: String,
-                      withIdIn: List[Long],
-                      license: Option[String],
-                      page: Int,
-                      pageSize: Int,
-                      sort: Sort.Value): Try[SearchResult[api.AgreementSummary]] = {
-
-      val fullQuery = boolQuery()
-        .must(
+      val fullQuery = settings.query match {
+        case Some(query) =>
           boolQuery()
-            .should(
-              queryStringQuery(query).field("title").boost(2),
-              queryStringQuery(query).field("content").boost(1)
-            ))
+            .must(
+              boolQuery()
+                .should(
+                  queryStringQuery(query).field("title").boost(2),
+                  queryStringQuery(query).field("content").boost(1)
+                ))
+        case None => boolQuery()
+      }
 
-      executeSearch(withIdIn, license, sort, page, pageSize, fullQuery)
+      executeSearch(settings, fullQuery)
     }
 
-    def executeSearch(withIdIn: List[Long],
-                      license: Option[String],
-                      sort: Sort.Value,
-                      page: Int,
-                      pageSize: Int,
+    def executeSearch(settings: AgreementSearchSettings,
                       queryBuilder: BoolQuery): Try[SearchResult[api.AgreementSummary]] = {
-      val idFilter = if (withIdIn.isEmpty) None else Some(idsQuery(withIdIn))
+      val idFilter = if (settings.withIdIn.isEmpty) None else Some(idsQuery(settings.withIdIn))
+
+      // TODO: License filter?
 
       val filters = List(idFilter)
       val filteredSearch = queryBuilder.filter(filters.flatten)
 
-      val (startAt, numResults) = getStartAtAndNumResults(page, pageSize)
-      val requestedResultWindow = pageSize * page
+      val (startAt, numResults) = getStartAtAndNumResults(settings.page, settings.pageSize)
+      val requestedResultWindow = settings.pageSize * settings.page
       if (requestedResultWindow > ElasticSearchIndexMaxResultWindow) {
         logger.info(
           s"Max supported results are $ElasticSearchIndexMaxResultWindow, user requested $requestedResultWindow")
@@ -87,18 +76,20 @@ trait AgreementSearchService {
           .size(numResults)
           .from(startAt)
           .query(filteredSearch)
-          .sortBy(getSortDefinition(sort))
+          .sortBy(getSortDefinition(settings.sort))
 
         // Only add scroll param if it is first page
         val searchWithScroll =
-          if (startAt != 0) { searchToExecute } else { searchToExecute.scroll(ElasticSearchScrollKeepAlive) }
+          if (startAt == 0 && settings.shouldScroll) {
+            searchToExecute.scroll(ElasticSearchScrollKeepAlive)
+          } else { searchToExecute }
 
         e4sClient.execute { searchWithScroll } match {
           case Success(response) =>
             Success(
               SearchResult(
                 response.result.totalHits,
-                Some(page),
+                Some(settings.page),
                 numResults,
                 Language.NoLanguage,
                 getHits(response.result, Language.NoLanguage),

--- a/src/main/scala/no/ndla/draftapi/service/search/ArticleSearchService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/search/ArticleSearchService.scala
@@ -114,7 +114,9 @@ trait ArticleSearchService {
           .sortBy(getSortDefinition(settings.sort, searchLanguage))
 
         val searchWithScroll =
-          if (startAt != 0) { searchToExecute } else { searchToExecute.scroll(ElasticSearchScrollKeepAlive) }
+          if (startAt == 0 && settings.shouldScroll) {
+            searchToExecute.scroll(ElasticSearchScrollKeepAlive)
+          } else { searchToExecute }
 
         e4sClient.execute(searchWithScroll) match {
           case Success(response) =>

--- a/src/main/scala/no/ndla/draftapi/service/search/ArticleSearchService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/search/ArticleSearchService.scala
@@ -39,91 +39,68 @@ trait ArticleSearchService {
     override def hitToApiModel(hit: String, language: String): api.ArticleSummary =
       searchConverterService.hitAsArticleSummary(hit, language)
 
-    def all(withIdIn: List[Long],
-            language: String,
-            license: Option[String],
-            page: Int,
-            pageSize: Int,
-            sort: Sort.Value,
-            articleTypes: Seq[String],
-            fallback: Boolean,
-            grepCodes: Seq[String]): Try[SearchResult[api.ArticleSummary]] =
-      executeSearch(withIdIn, language, license, sort, page, pageSize, boolQuery(), articleTypes, fallback, grepCodes)
+    def matchingQuery(settings: SearchSettings): Try[SearchResult[api.ArticleSummary]] = {
 
-    def matchingQuery(query: String,
-                      withIdIn: List[Long],
-                      searchLanguage: String,
-                      license: Option[String],
-                      page: Int,
-                      pageSize: Int,
-                      sort: Sort.Value,
-                      articleTypes: Seq[String],
-                      fallback: Boolean,
-                      grepCodes: Seq[String]): Try[SearchResult[api.ArticleSummary]] = {
+      val fullQuery = settings.query match {
+        case Some(query) =>
+          val language =
+            if (settings.searchLanguage == Language.AllLanguages || settings.fallback) "*" else settings.searchLanguage
+          val titleSearch = simpleStringQuery(query).field(s"title.$language", 6)
+          val introSearch = simpleStringQuery(query).field(s"introduction.$language", 2)
+          val contentSearch = simpleStringQuery(query).field(s"content.$language", 1)
+          val tagSearch = simpleStringQuery(query).field(s"tags.$language", 2)
+          val notesSearch = simpleStringQuery(query).field("notes", 1)
+          val previousNotesSearch = simpleStringQuery(query).field("previousNotes", 1)
 
-      val language = if (searchLanguage == Language.AllLanguages || fallback) "*" else searchLanguage
-      val titleSearch = simpleStringQuery(query).field(s"title.$language", 6)
-      val introSearch = simpleStringQuery(query).field(s"introduction.$language", 2)
-      val contentSearch = simpleStringQuery(query).field(s"content.$language", 1)
-      val tagSearch = simpleStringQuery(query).field(s"tags.$language", 2)
-      val notesSearch = simpleStringQuery(query).field("notes", 1)
-      val previousNotesSearch = simpleStringQuery(query).field("previousNotes", 1)
-
-      val fullQuery = boolQuery()
-        .must(
           boolQuery()
-            .should(
-              titleSearch,
-              introSearch,
-              contentSearch,
-              tagSearch,
-              notesSearch,
-              previousNotesSearch
+            .must(
+              boolQuery()
+                .should(
+                  titleSearch,
+                  introSearch,
+                  contentSearch,
+                  tagSearch,
+                  notesSearch,
+                  previousNotesSearch
+                )
             )
-        )
+        case None => boolQuery()
+      }
 
-      executeSearch(withIdIn, language, license, sort, page, pageSize, fullQuery, articleTypes, fallback, grepCodes)
+      executeSearch(settings, fullQuery)
     }
 
-    def executeSearch(withIdIn: List[Long],
-                      language: String,
-                      license: Option[String],
-                      sort: Sort.Value,
-                      page: Int,
-                      pageSize: Int,
-                      queryBuilder: BoolQuery,
-                      articleTypes: Seq[String],
-                      fallback: Boolean,
-                      grepCodes: Seq[String]): Try[SearchResult[api.ArticleSummary]] = {
+    def executeSearch(settings: SearchSettings, queryBuilder: BoolQuery): Try[SearchResult[api.ArticleSummary]] = {
 
       val articleTypesFilter =
-        if (articleTypes.nonEmpty) Some(constantScoreQuery(termsQuery("articleType", articleTypes))) else None
+        if (settings.articleTypes.nonEmpty) Some(constantScoreQuery(termsQuery("articleType", settings.articleTypes)))
+        else None
 
-      val licenseFilter = license match {
+      val licenseFilter = settings.license match {
         case None      => Some(noCopyright)
         case Some(lic) => Some(termQuery("license", lic))
       }
 
-      val idFilter = if (withIdIn.isEmpty) None else Some(idsQuery(withIdIn))
+      val idFilter = if (settings.withIdIn.isEmpty) None else Some(idsQuery(settings.withIdIn))
 
-      val (languageFilter, searchLanguage) = language match {
+      val (languageFilter, searchLanguage) = settings.searchLanguage match {
         case "" | Language.AllLanguages =>
           (None, "*")
         case lang =>
-          if (fallback)
+          if (settings.fallback)
             (None, "*")
           else
             (Some(existsQuery(s"title.$lang")), lang)
       }
 
       val grepCodesFilter =
-        if (grepCodes.nonEmpty) Some(constantScoreQuery(termsQuery("grepCodes", grepCodes))) else None
+        if (settings.grepCodes.nonEmpty) Some(constantScoreQuery(termsQuery("grepCodes", settings.grepCodes))) else None
 
       val filters = List(licenseFilter, idFilter, languageFilter, articleTypesFilter, grepCodesFilter)
       val filteredSearch = queryBuilder.filter(filters.flatten)
 
-      val (startAt, numResults) = getStartAtAndNumResults(page, pageSize)
-      val requestedResultWindow = pageSize * page
+      val (startAt, numResults) = getStartAtAndNumResults(settings.page, settings.pageSize)
+      val requestedResultWindow = settings.pageSize * settings.page
       if (requestedResultWindow > ElasticSearchIndexMaxResultWindow) {
         logger.info(
           s"Max supported results are $ElasticSearchIndexMaxResultWindow, user requested $requestedResultWindow")
@@ -134,7 +111,7 @@ trait ArticleSearchService {
           .from(startAt)
           .query(filteredSearch)
           .highlighting(highlight("*"))
-          .sortBy(getSortDefinition(sort, searchLanguage))
+          .sortBy(getSortDefinition(settings.sort, searchLanguage))
 
         val searchWithScroll =
           if (startAt != 0) { searchToExecute } else { searchToExecute.scroll(ElasticSearchScrollKeepAlive) }
@@ -144,10 +121,10 @@ trait ArticleSearchService {
             Success(
               SearchResult(
                 response.result.totalHits,
-                Some(page),
+                Some(settings.page),
                 numResults,
                 if (searchLanguage == "*") Language.AllLanguages else searchLanguage,
-                getHits(response.result, language),
+                getHits(response.result, settings.searchLanguage),
                 response.result.scrollId
               ))
           case Failure(ex) =>

--- a/src/main/scala/no/ndla/draftapi/service/search/SearchService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/search/SearchService.scala
@@ -75,33 +75,33 @@ trait SearchService {
       sort match {
         case Sort.ByTitleAsc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.ASC).missing("_last")
-            case _                           => fieldSort(s"title.$sortLanguage.raw").order(SortOrder.ASC).missing("_last")
+            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.Asc).missing("_last")
+            case _                           => fieldSort(s"title.$sortLanguage.raw").order(SortOrder.Asc).missing("_last")
           }
         case Sort.ByTitleDesc =>
           language match {
-            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.DESC).missing("_last")
-            case _                           => fieldSort(s"title.$sortLanguage.raw").order(SortOrder.DESC).missing("_last")
+            case "*" | Language.AllLanguages => fieldSort("defaultTitle").order(SortOrder.Desc).missing("_last")
+            case _                           => fieldSort(s"title.$sortLanguage.raw").order(SortOrder.Desc).missing("_last")
           }
-        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.ASC)
-        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.DESC)
-        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.ASC).missing("_last")
-        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.DESC).missing("_last")
-        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.ASC).missing("_last")
-        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.DESC).missing("_last")
+        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)
+        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.Desc)
+        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.Asc).missing("_last")
+        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.Desc).missing("_last")
+        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.Asc).missing("_last")
+        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.Desc).missing("_last")
       }
     }
 
     def getSortDefinition(sort: Sort.Value): FieldSort = {
       sort match {
-        case Sort.ByTitleAsc        => fieldSort("title.raw").order(SortOrder.ASC).missing("_last")
-        case Sort.ByTitleDesc       => fieldSort("title.raw").order(SortOrder.DESC).missing("_last")
-        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.ASC)
-        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.DESC)
-        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.ASC).missing("_last")
-        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.DESC).missing("_last")
-        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.ASC).missing("_last")
-        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.DESC).missing("_last")
+        case Sort.ByTitleAsc        => fieldSort("title.raw").order(SortOrder.Asc).missing("_last")
+        case Sort.ByTitleDesc       => fieldSort("title.raw").order(SortOrder.Desc).missing("_last")
+        case Sort.ByRelevanceAsc    => fieldSort("_score").order(SortOrder.Asc)
+        case Sort.ByRelevanceDesc   => fieldSort("_score").order(SortOrder.Desc)
+        case Sort.ByLastUpdatedAsc  => fieldSort("lastUpdated").order(SortOrder.Asc).missing("_last")
+        case Sort.ByLastUpdatedDesc => fieldSort("lastUpdated").order(SortOrder.Desc).missing("_last")
+        case Sort.ByIdAsc           => fieldSort("id").order(SortOrder.Asc).missing("_last")
+        case Sort.ByIdDesc          => fieldSort("id").order(SortOrder.Desc).missing("_last")
       }
     }
 

--- a/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -497,6 +497,17 @@ object TestData {
     sort = Sort.ByIdAsc,
     articleTypes = Seq.empty,
     fallback = false,
-    grepCodes = Seq.empty
+    grepCodes = Seq.empty,
+    shouldScroll = false
+  )
+
+  val agreementSearchSettings = AgreementSearchSettings(
+    query = None,
+    withIdIn = List.empty,
+    license = None,
+    page = 1,
+    pageSize = 10,
+    sort = Sort.ByIdAsc,
+    shouldScroll = false
   )
 }

--- a/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -486,4 +486,17 @@ object TestData {
 
   val sampleApiGrepCodesSearchResult = api.GrepCodesSearchResult(10, 1, 1, Seq("a", "b"))
   val sampleApiTagsSearchResult = api.TagsSearchResult(10, 1, 1, "nb", Seq("a", "b"))
+
+  val searchSettings = SearchSettings(
+    query = None,
+    withIdIn = List.empty,
+    searchLanguage = Language.DefaultLanguage,
+    license = None,
+    page = 1,
+    pageSize = 10,
+    sort = Sort.ByIdAsc,
+    articleTypes = Seq.empty,
+    fallback = false,
+    grepCodes = Seq.empty
+  )
 }

--- a/src/test/scala/no/ndla/draftapi/controller/AgreementControllerTest.scala
+++ b/src/test/scala/no/ndla/draftapi/controller/AgreementControllerTest.scala
@@ -7,7 +7,7 @@
 
 package no.ndla.draftapi.controller
 
-import no.ndla.draftapi.model.domain.{SearchResult, Sort}
+import no.ndla.draftapi.model.domain.{AgreementSearchSettings, SearchResult, Sort}
 import no.ndla.draftapi.model.api
 import no.ndla.draftapi.{DraftSwagger, TestData, TestEnvironment, UnitSuite}
 import org.json4s.DefaultFormats
@@ -62,7 +62,7 @@ class AgreementControllerTest extends UnitSuite with TestEnvironment with Scalat
       Seq.empty[api.AgreementSummary],
       Some(scrollId)
     )
-    when(agreementSearchService.all(any[List[Long]], any[Option[String]], any[Int], any[Int], any[Sort.Value]))
+    when(agreementSearchService.matchingQuery(any[AgreementSearchSettings]))
       .thenReturn(Success(searchResponse))
 
     get(s"/test/") {
@@ -91,17 +91,7 @@ class AgreementControllerTest extends UnitSuite with TestEnvironment with Scalat
       status should be(200)
     }
 
-    verify(agreementSearchService, times(0)).all(any[List[Long]],
-                                                 any[Option[String]],
-                                                 any[Int],
-                                                 any[Int],
-                                                 any[Sort.Value])
-    verify(agreementSearchService, times(0)).matchingQuery(any[String],
-                                                           any[List[Long]],
-                                                           any[Option[String]],
-                                                           any[Int],
-                                                           any[Int],
-                                                           any[Sort.Value])
+    verify(agreementSearchService, times(0)).matchingQuery(any[AgreementSearchSettings])
     verify(agreementSearchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 

--- a/src/test/scala/no/ndla/draftapi/controller/DraftControllerTest.scala
+++ b/src/test/scala/no/ndla/draftapi/controller/DraftControllerTest.scala
@@ -12,7 +12,7 @@ import java.util.Date
 import no.ndla.draftapi.TestData.authHeaderWithWriteRole
 import no.ndla.draftapi.auth.UserInfo
 import no.ndla.draftapi.model.api._
-import no.ndla.draftapi.model.domain.{ArticleType, Language, Sort}
+import no.ndla.draftapi.model.domain.{ArticleType, Language, SearchSettings, Sort}
 import no.ndla.draftapi.model.{api, domain}
 import no.ndla.draftapi.{DraftSwagger, TestData, TestEnvironment, UnitSuite}
 import no.ndla.mapping.License.getLicenses
@@ -90,29 +90,21 @@ class DraftControllerTest extends UnitSuite with TestEnvironment with ScalatraFu
   test("GET / should use size of id-list as page-size if defined") {
     val searchMock = mock[domain.SearchResult[api.ArticleSummary]]
     when(searchMock.scrollId).thenReturn(None)
-    when(
-      articleSearchService.all(any[List[Long]],
-                               any[String],
-                               any[Option[String]],
-                               any[Int],
-                               any[Int],
-                               any[Sort.Value],
-                               any[Seq[String]],
-                               any[Boolean],
-                               any[Seq[String]]))
+    when(articleSearchService.matchingQuery(any[SearchSettings]))
       .thenReturn(Success(searchMock))
 
     get("/test/", "ids" -> "1,2,3,4", "page-size" -> "10", "language" -> "nb") {
       status should equal(200)
-      verify(articleSearchService, times(1)).all(List(1, 2, 3, 4),
-                                                 Language.DefaultLanguage,
-                                                 None,
-                                                 1,
-                                                 4,
-                                                 Sort.ByTitleAsc,
-                                                 ArticleType.all,
-                                                 fallback = false,
-                                                 grepCodes = Seq.empty)
+
+      verify(articleSearchService, times(1)).matchingQuery(
+        TestData.searchSettings.copy(
+          withIdIn = List(1, 2, 3, 4),
+          searchLanguage = Language.DefaultLanguage,
+          page = 1,
+          pageSize = 4,
+          sort = Sort.ByTitleAsc,
+          articleTypes = ArticleType.all
+        ))
     }
   }
 
@@ -237,17 +229,7 @@ class DraftControllerTest extends UnitSuite with TestEnvironment with ScalatraFu
       Seq.empty[api.ArticleSummary],
       Some(scrollId)
     )
-    when(
-      articleSearchService.all(any[List[Long]],
-                               any[String],
-                               any[Option[String]],
-                               any[Int],
-                               any[Int],
-                               any[Sort.Value],
-                               any[Seq[String]],
-                               any[Boolean],
-                               any[Seq[String]]))
-      .thenReturn(Success(searchResponse))
+    when(articleSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(searchResponse))
 
     get(s"/test/") {
       status should be(200)
@@ -275,25 +257,7 @@ class DraftControllerTest extends UnitSuite with TestEnvironment with ScalatraFu
       status should be(200)
     }
 
-    verify(articleSearchService, times(0)).all(any[List[Long]],
-                                               any[String],
-                                               any[Option[String]],
-                                               any[Int],
-                                               any[Int],
-                                               any[Sort.Value],
-                                               any[Seq[String]],
-                                               any[Boolean],
-                                               any[Seq[String]])
-    verify(articleSearchService, times(0)).matchingQuery(any[String],
-                                                         any[List[Long]],
-                                                         any[String],
-                                                         any[Option[String]],
-                                                         any[Int],
-                                                         any[Int],
-                                                         any[Sort.Value],
-                                                         any[Seq[String]],
-                                                         any[Boolean],
-                                                         any[Seq[String]])
+    verify(articleSearchService, times(0)).matchingQuery(any[SearchSettings])
     verify(articleSearchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 
@@ -316,25 +280,7 @@ class DraftControllerTest extends UnitSuite with TestEnvironment with ScalatraFu
       status should be(200)
     }
 
-    verify(articleSearchService, times(0)).all(any[List[Long]],
-                                               any[String],
-                                               any[Option[String]],
-                                               any[Int],
-                                               any[Int],
-                                               any[Sort.Value],
-                                               any[Seq[String]],
-                                               any[Boolean],
-                                               any[Seq[String]])
-    verify(articleSearchService, times(0)).matchingQuery(any[String],
-                                                         any[List[Long]],
-                                                         any[String],
-                                                         any[Option[String]],
-                                                         any[Int],
-                                                         any[Int],
-                                                         any[Sort.Value],
-                                                         any[Seq[String]],
-                                                         any[Boolean],
-                                                         any[Seq[String]])
+    verify(articleSearchService, times(0)).matchingQuery(any[SearchSettings])
     verify(articleSearchService, times(1)).scroll(eqTo(scrollId), any[String])
   }
 

--- a/src/test/scala/no/ndla/draftapi/service/search/ArticleSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/search/ArticleSearchServiceTest.scala
@@ -12,6 +12,7 @@ import java.util.Date
 
 import com.sksamuel.elastic4s.embedded.LocalNode
 import no.ndla.draftapi.DraftApiProperties.DefaultPageSize
+import no.ndla.draftapi.TestData.searchSettings
 import no.ndla.draftapi._
 import no.ndla.draftapi.integration.{Elastic4sClientFactory, NdlaE4sClient}
 import no.ndla.draftapi.model.domain._
@@ -230,41 +231,26 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("all should return only articles of a given type if a type filter is specified") {
-    val Success(results) = articleSearchService.all(List(),
-                                                    Language.DefaultLanguage,
-                                                    None,
-                                                    1,
-                                                    10,
-                                                    Sort.ByIdAsc,
-                                                    Seq(ArticleType.TopicArticle.toString),
-                                                    fallback = false,
-                                                    grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        articleTypes = Seq(ArticleType.TopicArticle.toString)
+      ))
     results.totalCount should be(3)
     results.results.map(_.id) should be(Seq(8, 9, 11))
 
-    val Success(results2) = articleSearchService.all(List(),
-                                                     Language.DefaultLanguage,
-                                                     None,
-                                                     1,
-                                                     10,
-                                                     Sort.ByIdAsc,
-                                                     ArticleType.all,
-                                                     fallback = false,
-                                                     grepCodes = Seq.empty)
+    val Success(results2) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = Language.DefaultLanguage,
+        articleTypes = ArticleType.all
+      ))
     results2.totalCount should be(9)
   }
 
   test("That all returns all documents ordered by id ascending") {
-    val Success(results) =
-      articleSearchService.all(List(),
-                               Language.DefaultLanguage,
-                               None,
-                               1,
-                               10,
-                               Sort.ByIdAsc,
-                               Seq.empty,
-                               fallback = false,
-                               grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByIdAsc
+      ))
     val hits = results.results
     results.totalCount should be(9)
     hits.head.id should be(1)
@@ -279,15 +265,10 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That all returns all documents ordered by id descending") {
-    val Success(results) = articleSearchService.all(List(),
-                                                    Language.DefaultLanguage,
-                                                    None,
-                                                    1,
-                                                    10,
-                                                    Sort.ByIdDesc,
-                                                    Seq.empty,
-                                                    fallback = false,
-                                                    grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByIdDesc
+      ))
     val hits = results.results
     results.totalCount should be(9)
     hits.head.id should be(11)
@@ -295,15 +276,10 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That all returns all documents ordered by title ascending") {
-    val Success(results) = articleSearchService.all(List(),
-                                                    Language.DefaultLanguage,
-                                                    None,
-                                                    1,
-                                                    10,
-                                                    Sort.ByTitleAsc,
-                                                    Seq.empty,
-                                                    fallback = false,
-                                                    grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByTitleAsc
+      ))
     val hits = results.results
     results.totalCount should be(9)
     hits.head.id should be(8)
@@ -318,15 +294,10 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That all returns all documents ordered by title descending") {
-    val Success(results) = articleSearchService.all(List(),
-                                                    Language.DefaultLanguage,
-                                                    None,
-                                                    1,
-                                                    10,
-                                                    Sort.ByTitleDesc,
-                                                    Seq.empty,
-                                                    fallback = false,
-                                                    grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByTitleDesc
+      ))
     val hits = results.results
     results.totalCount should be(9)
     hits.head.id should be(7)
@@ -341,15 +312,10 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That all returns all documents ordered by lastUpdated descending") {
-    val Success(results) = articleSearchService.all(List(),
-                                                    Language.DefaultLanguage,
-                                                    None,
-                                                    1,
-                                                    10,
-                                                    Sort.ByLastUpdatedDesc,
-                                                    Seq.empty,
-                                                    fallback = false,
-                                                    grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByLastUpdatedDesc
+      ))
     val hits = results.results
     results.totalCount should be(9)
     hits.head.id should be(3)
@@ -357,15 +323,10 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That all returns all documents ordered by lastUpdated ascending") {
-    val Success(results) = articleSearchService.all(List(),
-                                                    Language.DefaultLanguage,
-                                                    None,
-                                                    1,
-                                                    10,
-                                                    Sort.ByLastUpdatedAsc,
-                                                    Seq.empty,
-                                                    fallback = false,
-                                                    grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        sort = Sort.ByLastUpdatedAsc
+      ))
     val hits = results.results
     results.totalCount should be(9)
     hits.head.id should be(5)
@@ -380,15 +341,11 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That all filtering on license only returns documents with given license") {
-    val Success(results) = articleSearchService.all(List(),
-                                                    Language.DefaultLanguage,
-                                                    Some("publicdomain"),
-                                                    1,
-                                                    10,
-                                                    Sort.ByTitleAsc,
-                                                    Seq.empty,
-                                                    fallback = false,
-                                                    grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        license = Some("publicdomain"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits = results.results
     results.totalCount should be(8)
     hits.head.id should be(8)
@@ -402,15 +359,10 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That all filtered by id only returns documents with the given ids") {
-    val Success(results) = articleSearchService.all(List(1, 3),
-                                                    Language.DefaultLanguage,
-                                                    None,
-                                                    1,
-                                                    10,
-                                                    Sort.ByIdAsc,
-                                                    Seq.empty,
-                                                    fallback = false,
-                                                    grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        withIdIn = List(1, 3)
+      ))
     val hits = results.results
     results.totalCount should be(2)
     hits.head.id should be(1)
@@ -418,15 +370,12 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That paging returns only hits on current page and not more than page-size") {
-    val Success(page1) = articleSearchService.all(List(),
-                                                  Language.DefaultLanguage,
-                                                  None,
-                                                  1,
-                                                  2,
-                                                  Sort.ByTitleAsc,
-                                                  Seq.empty,
-                                                  fallback = false,
-                                                  grepCodes = Seq.empty)
+    val Success(page1) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        page = 1,
+        pageSize = 2,
+        sort = Sort.ByTitleAsc
+      ))
     val hits1 = page1.results
     page1.totalCount should be(9)
     page1.page.get should be(1)
@@ -434,15 +383,13 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
     hits1.head.id should be(8)
     hits1.last.id should be(9)
 
-    val Success(page2) = articleSearchService.all(List(),
-                                                  Language.DefaultLanguage,
-                                                  None,
-                                                  2,
-                                                  2,
-                                                  Sort.ByTitleAsc,
-                                                  Seq.empty,
-                                                  fallback = false,
-                                                  grepCodes = Seq.empty)
+    val Success(page2) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        page = 2,
+        pageSize = 2,
+        sort = Sort.ByTitleAsc
+      ))
+
     val hits2 = page2.results
     page2.totalCount should be(9)
     page2.page.get should be(2)
@@ -452,42 +399,31 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("mathcingQuery should filter results based on an article type filter") {
-    val Success(results) = articleSearchService.matchingQuery("bil",
-                                                              List(),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByRelevanceDesc,
-                                                              Seq(ArticleType.TopicArticle.toString),
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("bil"),
+        sort = Sort.ByRelevanceDesc,
+        articleTypes = Seq(ArticleType.TopicArticle.toString)
+      ))
     results.totalCount should be(0)
 
-    val Success(results2) = articleSearchService.matchingQuery("bil",
-                                                               List(),
-                                                               "nb",
-                                                               None,
-                                                               1,
-                                                               10,
-                                                               Sort.ByRelevanceDesc,
-                                                               Seq(ArticleType.Standard.toString),
-                                                               fallback = false,
-                                                               grepCodes = Seq.empty)
+    val Success(results2) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("bil"),
+        sort = Sort.ByRelevanceDesc,
+        articleTypes = Seq(ArticleType.Standard.toString)
+      ))
+
     results2.totalCount should be(3)
   }
 
   test("That search matches title and html-content ordered by relevance descending") {
-    val Success(results) = articleSearchService.matchingQuery("bil",
-                                                              List(),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByRelevanceDesc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("bil"),
+        sort = Sort.ByRelevanceDesc,
+      ))
+
     val hits = results.results
     results.totalCount should be(3)
     hits.head.id should be(5)
@@ -496,179 +432,121 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That search combined with filter by id only returns documents matching the query with one of the given ids") {
-    val Success(results) = articleSearchService.matchingQuery("bil",
-                                                              List(3),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByRelevanceDesc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("bil"),
+        withIdIn = List(3),
+        sort = Sort.ByRelevanceDesc,
+      ))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(3)
   }
 
   test("That search matches title") {
-    val Success(results) = articleSearchService.matchingQuery("Pingvinen",
-                                                              List(),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByTitleAsc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("Pingvinen"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(2)
   }
 
   test("That search matches tags") {
-    val Success(results) =
-      articleSearchService.matchingQuery("and",
-                                         List(),
-                                         "nb",
-                                         None,
-                                         1,
-                                         10,
-                                         Sort.ByTitleAsc,
-                                         Seq.empty,
-                                         fallback = false,
-                                         grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("and"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(3)
   }
 
   test("That search does not return superman since it has license copyrighted and license is not specified") {
-    val Success(results) = articleSearchService.matchingQuery("supermann",
-                                                              List(),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByTitleAsc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("supermann"),
+        sort = Sort.ByTitleAsc
+      ))
     results.totalCount should be(0)
   }
 
   test("That search returns superman since license is specified as copyrighted") {
-    val Success(results) = articleSearchService.matchingQuery("supermann",
-                                                              List(),
-                                                              "nb",
-                                                              Some("copyrighted"),
-                                                              1,
-                                                              10,
-                                                              Sort.ByTitleAsc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(results) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("supermann"),
+        license = Some("copyrighted"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits = results.results
     results.totalCount should be(1)
     hits.head.id should be(4)
   }
 
   test("Searching with logical AND only returns results with all terms") {
-    val Success(search1) = articleSearchService.matchingQuery("bilde + bil",
-                                                              List(),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByTitleAsc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(search1) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("bilde + bil"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits1 = search1.results
     hits1.map(_.id) should equal(Seq(1, 3, 5))
 
-    val Success(search2) = articleSearchService.matchingQuery("batmen + bil",
-                                                              List(),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByTitleAsc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(search2) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("batmen + bil"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits2 = search2.results
     hits2.map(_.id) should equal(Seq(1))
 
-    val Success(search3) = articleSearchService.matchingQuery("bil + bilde - flaggermusmann",
-                                                              List(),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByTitleAsc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(search3) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("bil + bilde - flaggermusmann"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits3 = search3.results
     hits3.map(_.id) should equal(Seq(1, 3, 5))
 
-    val Success(search4) = articleSearchService.matchingQuery("bil - hulken",
-                                                              List(),
-                                                              "nb",
-                                                              None,
-                                                              1,
-                                                              10,
-                                                              Sort.ByTitleAsc,
-                                                              Seq.empty,
-                                                              fallback = false,
-                                                              grepCodes = Seq.empty)
+    val Success(search4) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("bil - hulken"),
+        sort = Sort.ByTitleAsc
+      ))
     val hits4 = search4.results
     hits4.map(_.id) should equal(Seq(1, 3, 5))
   }
 
   test("search in content should be ranked lower than introduction and title") {
-    val Success(search) = articleSearchService.matchingQuery("mareritt + ragnarok",
-                                                             List(),
-                                                             "nb",
-                                                             None,
-                                                             1,
-                                                             10,
-                                                             Sort.ByRelevanceDesc,
-                                                             Seq.empty,
-                                                             fallback = false,
-                                                             grepCodes = Seq.empty)
+    val Success(search) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("mareritt + ragnarok"),
+        sort = Sort.ByRelevanceDesc
+      ))
     val hits = search.results
     hits.map(_.id) should equal(Seq(9, 8))
   }
 
   test("searching for notes should return relevant results") {
-    val Success(search) = articleSearchService.matchingQuery("kakemonster",
-                                                             List(),
-                                                             "nb",
-                                                             None,
-                                                             1,
-                                                             10,
-                                                             Sort.ByRelevanceDesc,
-                                                             Seq.empty,
-                                                             fallback = false,
-                                                             grepCodes = Seq.empty)
+    val Success(search) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("kakemonster"),
+        sort = Sort.ByRelevanceDesc
+      ))
     search.totalCount should be(1)
     search.results.head.id should be(5)
   }
 
   test("Search for all languages should return all articles in correct language") {
-    val Success(search) =
-      articleSearchService.all(List(),
-                               Language.AllLanguages,
-                               None,
-                               1,
-                               100,
-                               Sort.ByIdAsc,
-                               Seq.empty,
-                               fallback = false,
-                               grepCodes = Seq.empty)
+    val Success(search) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = Language.AllLanguages,
+        sort = Sort.ByIdAsc,
+        pageSize = 100
+      ))
     val hits = search.results
 
     search.totalCount should equal(10)
@@ -687,15 +565,13 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("Search for all languages should return all languages if copyrighted") {
-    val Success(search) = articleSearchService.all(List(),
-                                                   Language.AllLanguages,
-                                                   Some("copyrighted"),
-                                                   1,
-                                                   100,
-                                                   Sort.ByTitleAsc,
-                                                   Seq.empty,
-                                                   fallback = false,
-                                                   grepCodes = Seq.empty)
+    val Success(search) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = Language.AllLanguages,
+        license = Some("copyrighted"),
+        sort = Sort.ByTitleAsc,
+        pageSize = 100
+      ))
     val hits = search.results
 
     search.totalCount should equal(1)
@@ -703,26 +579,18 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("Searching with query for all languages should return language that matched") {
-    val Success(searchEn) = articleSearchService.matchingQuery("Big",
-                                                               List(),
-                                                               "all",
-                                                               None,
-                                                               1,
-                                                               10,
-                                                               Sort.ByRelevanceDesc,
-                                                               Seq.empty,
-                                                               fallback = false,
-                                                               grepCodes = Seq.empty)
-    val Success(searchNb) = articleSearchService.matchingQuery("Store",
-                                                               List(),
-                                                               "all",
-                                                               None,
-                                                               1,
-                                                               10,
-                                                               Sort.ByRelevanceDesc,
-                                                               Seq.empty,
-                                                               fallback = false,
-                                                               grepCodes = Seq.empty)
+    val Success(searchEn) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("Big"),
+        searchLanguage = Language.AllLanguages,
+        sort = Sort.ByRelevanceDesc,
+      ))
+    val Success(searchNb) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("Store"),
+        searchLanguage = Language.AllLanguages,
+        sort = Sort.ByRelevanceDesc,
+      ))
 
     searchEn.totalCount should equal(1)
     searchEn.results.head.id should equal(11)
@@ -736,16 +604,12 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That searching with fallback parameter returns article in language priority even if doesnt match on language") {
-    val Success(search) =
-      articleSearchService.all(List(9, 10, 11),
-                               "en",
-                               None,
-                               1,
-                               10,
-                               Sort.ByIdAsc,
-                               Seq.empty,
-                               fallback = true,
-                               grepCodes = Seq.empty)
+    val Success(search) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        withIdIn = List(9, 10, 11),
+        searchLanguage = "en",
+        fallback = true
+      ))
 
     search.totalCount should equal(3)
     search.results.head.id should equal(9)
@@ -760,16 +624,12 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
     val pageSize = 2
     val expectedIds = List(1, 2, 3, 5, 6, 7, 8, 9, 10, 11).sliding(pageSize, pageSize).toList
 
-    val Success(initialSearch) =
-      articleSearchService.all(List.empty,
-                               "all",
-                               None,
-                               1,
-                               pageSize,
-                               Sort.ByIdAsc,
-                               Seq.empty,
-                               fallback = true,
-                               grepCodes = Seq.empty)
+    val Success(initialSearch) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = Language.AllLanguages,
+        fallback = true,
+        pageSize = pageSize
+      ))
 
     val Success(scroll1) = articleSearchService.scroll(initialSearch.scrollId.get, "all")
     val Success(scroll2) = articleSearchService.scroll(scroll1.scrollId.get, "all")
@@ -786,17 +646,13 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
   }
 
   test("That highlighting works when scrolling") {
-    val Success(initialSearch) =
-      articleSearchService.matchingQuery("about",
-                                         List.empty,
-                                         "all",
-                                         None,
-                                         1,
-                                         1,
-                                         Sort.ByIdAsc,
-                                         Seq.empty,
-                                         fallback = true,
-                                         grepCodes = Seq.empty)
+    val Success(initialSearch) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        query = Some("about"),
+        searchLanguage = Language.AllLanguages,
+        fallback = true,
+        pageSize = 1
+      ))
     val Success(scroll) = articleSearchService.scroll(initialSearch.scrollId.get, "all")
 
     initialSearch.results.size should be(1)
@@ -810,50 +666,35 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
 
   test("searching for previousnotes should return relevant results") {
     val Success(search) = articleSearchService.matchingQuery(
-      "kyllingkanon",
-      List(),
-      "nb",
-      None,
-      1,
-      10,
-      Sort.ByRelevanceDesc,
-      Seq.empty,
-      fallback = false,
-      grepCodes = Seq.empty
-    )
+      searchSettings.copy(
+        query = Some("kyllingkanon"),
+        sort = Sort.ByRelevanceDesc
+      ))
+
     search.totalCount should be(1)
     search.results.head.id should be(5)
   }
 
   test("That fallback searches for title in other languages as well") {
     val Success(search) = articleSearchService.matchingQuery(
-      "\"in english\"",
-      List(),
-      "nb",
-      None,
-      1,
-      10,
-      Sort.ByRelevanceDesc,
-      Seq.empty,
-      fallback = true,
-      grepCodes = Seq.empty
-    )
+      searchSettings.copy(
+        query = Some("\"in english\""),
+        searchLanguage = "nb",
+        sort = Sort.ByRelevanceDesc,
+        fallback = true
+      ))
 
     search.results.map(_.id) should be(Seq(10))
   }
 
   test("searching for grepCodes should return relevant results") {
-    val Success(search) = articleSearchService.all(
-      List(),
-      "nb",
-      None,
-      1,
-      10,
-      Sort.ByRelevanceDesc,
-      Seq.empty,
-      fallback = true,
-      grepCodes = Seq("KM1234")
-    )
+    val Success(search) = articleSearchService.matchingQuery(
+      searchSettings.copy(
+        searchLanguage = "nb",
+        sort = Sort.ByRelevanceDesc,
+        fallback = true,
+        grepCodes = Seq("KM1234")
+      ))
     search.totalCount should be(1)
     search.results.head.id should be(5)
   }

--- a/src/test/scala/no/ndla/draftapi/service/search/ArticleSearchServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/search/ArticleSearchServiceTest.scala
@@ -628,7 +628,8 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
       searchSettings.copy(
         searchLanguage = Language.AllLanguages,
         fallback = true,
-        pageSize = pageSize
+        pageSize = pageSize,
+        shouldScroll = true
       ))
 
     val Success(scroll1) = articleSearchService.scroll(initialSearch.scrollId.get, "all")
@@ -651,7 +652,8 @@ class ArticleSearchServiceTest extends IntegrationSuite(withSearch = true) with 
         query = Some("about"),
         searchLanguage = Language.AllLanguages,
         fallback = true,
-        pageSize = 1
+        pageSize = 1,
+        shouldScroll = true
       ))
     val Success(scroll) = articleSearchService.scroll(initialSearch.scrollId.get, "all")
 


### PR DESCRIPTION
Relates to NDLANO/Issues#2226