### PR TITLE
#2434: Fix search-context=initial (++)

### DIFF
--- a/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -79,14 +79,14 @@ trait DraftController {
       */
     private def scrollSearchOr(scrollId: Option[String], language: String)(orFunction: => Any): Any = {
       scrollId match {
-        case Some(scroll) =>
+        case Some(scroll) if !InitialScrollContextKeywords.contains(scroll) =>
           articleSearchService.scroll(scroll, language) match {
             case Success(scrollResult) =>
               val responseHeader = scrollResult.scrollId.map(i => this.scrollId.paramName -> i).toMap
               Ok(searchConverterService.asApiSearchResult(scrollResult), headers = responseHeader)
             case Failure(ex) => errorHandler(ex)
           }
-        case None => orFunction
+        case _ => orFunction
       }
     }
 

--- a/src/test/scala/no/ndla/draftapi/controller/DraftControllerTest.scala
+++ b/src/test/scala/no/ndla/draftapi/controller/DraftControllerTest.scala
@@ -392,4 +392,32 @@ class DraftControllerTest extends UnitSuite with TestEnvironment with ScalatraFu
     }
   }
 
+  test("that initial search-context doesn't scroll") {
+    reset(articleSearchService)
+
+    val expectedSettings = TestData.searchSettings.copy(
+      searchLanguage = "all",
+      articleTypes = List("standard", "topic-article"),
+      shouldScroll = true,
+      sort = Sort.ByTitleAsc
+    )
+
+    val result = domain.SearchResult[api.ArticleSummary](
+      totalCount = 0,
+      page = None,
+      pageSize = 10,
+      language = "all",
+      results = Seq.empty,
+      scrollId = Some("heiheihei")
+    )
+    when(articleSearchService.matchingQuery(any[SearchSettings])).thenReturn(Success(result))
+
+    get("/test/?search-context=initial") {
+      status should be(200)
+      verify(articleSearchService, times(1)).matchingQuery(expectedSettings)
+      verify(articleSearchService, times(0)).scroll(any[String], any[String])
+    }
+
+  }
+
 }


### PR DESCRIPTION
Relates to NDLANO/Issues#2434

Fikser så søk med search-context=initial (og de andre) fungerer som forventet og returnerer en search-context header
Søk uten search-context returnerer ingenting