### PR TITLE
2448 related content as article metadata

### DIFF
--- a/src/main/scala/no/ndla/draftapi/model/api/Article.scala
+++ b/src/main/scala/no/ndla/draftapi/model/api/Article.scala
@@ -39,5 +39,6 @@ case class Article(
     @(ApiModelProperty @field)(description = "The labels attached to this article; meant for editors.") editorLabels: Seq[String],
     @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Seq[String],
     @(ApiModelProperty @field)(description = "A list of conceptIds connected to the article") conceptIds: Seq[Long],
-    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/student/teacher") availability: String
-)
+    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/student/teacher") availability: String,
+    @(ApiModelProperty @field)(description = "A list of content related to the article") relatedContent: Seq[RelatedContent]
+                  )

--- a/src/main/scala/no/ndla/draftapi/model/api/ArticleApiArticle.scala
+++ b/src/main/scala/no/ndla/draftapi/model/api/ArticleApiArticle.scala
@@ -27,7 +27,8 @@ case class ArticleApiArticle(revision: Option[Int],
                              articleType: String,
                              grepCodes: Seq[String],
                              conceptIds: Seq[Long],
-                             availability: Availability.Value)
+                             availability: Availability.Value,
+                             relatedContent: Seq[RelatedContent])
 case class ArticleApiTitle(title: String, language: String)
 case class ArticleApiContent(content: String, language: String)
 case class ArticleApiAuthor(`type`: String, name: String)

--- a/src/main/scala/no/ndla/draftapi/model/api/NewArticle.scala
+++ b/src/main/scala/no/ndla/draftapi/model/api/NewArticle.scala
@@ -30,5 +30,6 @@ case class NewArticle(
     @(ApiModelProperty @field)(description = "The labels attached to this article; meant for editors.") editorLabels: Seq[String],
     @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Seq[String],
     @(ApiModelProperty @field)(description = "A list of conceptIds connected to the article") conceptIds: Seq[Long],
-    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/student/teacher") availability: Option[String]
+    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/student/teacher") availability: Option[String],
+    @(ApiModelProperty @field)(description = "A list of content related to the article") relatedContent: Seq[RelatedContent]
 )

--- a/src/main/scala/no/ndla/draftapi/model/api/RelatedContentLink.scala
+++ b/src/main/scala/no/ndla/draftapi/model/api/RelatedContentLink.scala
@@ -1,0 +1,16 @@
+/*
+ * Part of NDLA draft_api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.model.api
+
+import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
+import scala.annotation.meta.field
+
+@ApiModel(description = "Information about a library required to render the article")
+case class RelatedContentLink(
+    @(ApiModelProperty @field)(description = "The type of the library. E.g. CSS or JavaScript") title: String,
+    @(ApiModelProperty @field)(description = "The full url to where the library can be downloaded") url: String)

--- a/src/main/scala/no/ndla/draftapi/model/api/RelatedContentLink.scala
+++ b/src/main/scala/no/ndla/draftapi/model/api/RelatedContentLink.scala
@@ -10,7 +10,7 @@ package no.ndla.draftapi.model.api
 import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 import scala.annotation.meta.field
 
-@ApiModel(description = "Information about a library required to render the article")
+@ApiModel(description = "External link related to the article")
 case class RelatedContentLink(
-    @(ApiModelProperty @field)(description = "The type of the library. E.g. CSS or JavaScript") title: String,
-    @(ApiModelProperty @field)(description = "The full url to where the library can be downloaded") url: String)
+    @(ApiModelProperty @field)(description = "Title of the article") title: String,
+    @(ApiModelProperty @field)(description = "The url to where the article can be viewed") url: String)

--- a/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
+++ b/src/main/scala/no/ndla/draftapi/model/api/UpdatedArticle.scala
@@ -34,5 +34,6 @@ case class UpdatedArticle(
     @(ApiModelProperty @field)(description = "A list of codes from GREP API connected to the article") grepCodes: Option[Seq[String]],
     @(ApiModelProperty @field)(description = "A list of conceptIds connected to the article") conceptIds: Option[Seq[Long]],
     @(ApiModelProperty @field)(description = "Stores the new article as a separate version. Useful when making big changes that should be revertable.") createNewVersion: Option[Boolean],
-    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/student/teacher") availability: Option[String]
-)
+    @(ApiModelProperty @field)(description = "Value that dictates who gets to see the article. Possible values are: everyone/student/teacher") availability: Option[String],
+    @(ApiModelProperty @field)(description = "A list of content related to the article") relatedContent: Option[Seq[RelatedContent]]
+                         )

--- a/src/main/scala/no/ndla/draftapi/model/api/package.scala
+++ b/src/main/scala/no/ndla/draftapi/model/api/package.scala
@@ -9,4 +9,5 @@ package no.ndla.draftapi.model
 
 package object api {
   type Deletable[T] = Either[Null, Option[T]] // We use this type to make json4s understand the difference between null and missing fields
+  type RelatedContent = Either[api.RelatedContentLink, Long];
 }

--- a/src/main/scala/no/ndla/draftapi/model/domain/Content.scala
+++ b/src/main/scala/no/ndla/draftapi/model/domain/Content.scala
@@ -8,7 +8,6 @@
 package no.ndla.draftapi.model.domain
 
 import java.util.Date
-
 import no.ndla.draftapi.DraftApiProperties
 import no.ndla.draftapi.model.domain.Language.getSupportedLanguages
 import no.ndla.validation.{ValidationException, ValidationMessage}
@@ -47,7 +46,8 @@ case class Article(
     editorLabels: Seq[String],
     grepCodes: Seq[String],
     conceptIds: Seq[Long],
-    availability: Availability.Value = Availability.everyone
+    availability: Availability.Value = Availability.everyone,
+    relatedContent: Seq[RelatedContent]
 ) extends Content {
 
   def supportedLanguages: Seq[String] =

--- a/src/main/scala/no/ndla/draftapi/model/domain/RelatedContentLink.scala
+++ b/src/main/scala/no/ndla/draftapi/model/domain/RelatedContentLink.scala
@@ -1,0 +1,11 @@
+/*
+ * Part of NDLA article_api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ *
+ */
+
+package no.ndla.draftapi.model.domain
+
+case class RelatedContentLink(url: String, title: String)

--- a/src/main/scala/no/ndla/draftapi/model/domain/RelatedContentLink.scala
+++ b/src/main/scala/no/ndla/draftapi/model/domain/RelatedContentLink.scala
@@ -8,4 +8,4 @@
 
 package no.ndla.draftapi.model.domain
 
-case class RelatedContentLink(url: String, title: String)
+case class RelatedContentLink(title: String, url: String)

--- a/src/main/scala/no/ndla/draftapi/model/domain/package.scala
+++ b/src/main/scala/no/ndla/draftapi/model/domain/package.scala
@@ -12,6 +12,8 @@ package object domain {
     lang.filter(_.nonEmpty)
   }
 
+  type RelatedContent = Either[RelatedContentLink, Long]
+
   case class ArticleIds(articleId: Long, externalId: List[String], importId: Option[String] = None)
   case class ImportId(importId: Option[String])
 }

--- a/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/ConverterService.scala
@@ -570,7 +570,10 @@ trait ConverterService {
                 editorLabels = updatedWithClonedFiles.editorLabels.getOrElse(toMergeInto.editorLabels),
                 grepCodes = updatedWithClonedFiles.grepCodes.getOrElse(toMergeInto.grepCodes),
                 conceptIds = updatedWithClonedFiles.conceptIds.getOrElse(toMergeInto.conceptIds),
-                availability = updatedAvailability
+                availability = updatedAvailability,
+                relatedContent = updatedWithClonedFiles.relatedContent
+                  .map(toDomainRelatedContent)
+                  .getOrElse(toMergeInto.relatedContent)
               )
 
               updatedWithClonedFiles.language match {

--- a/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -90,7 +90,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    availability = "everyone"
+    availability = "everyone",
+    Seq.empty
   )
 
   val blankUpdatedArticle = api.UpdatedArticle(
@@ -104,6 +105,7 @@ object TestData {
     None,
     None,
     Right(None),
+    None,
     None,
     None,
     None,
@@ -188,7 +190,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    availability = "everyone"
+    availability = "everyone",
+    Seq.empty
   )
 
   val apiArticleUserTest = api.Article(
@@ -228,7 +231,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    availability = "everyone"
+    availability = "everyone",
+    Seq.empty
   )
 
   val sampleTopicArticle = Article(
@@ -254,7 +258,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    Availability.everyone
+    Availability.everyone,
+    Seq.empty
   )
 
   val sampleArticleWithPublicDomain = Article(
@@ -280,7 +285,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    Availability.everyone
+    Availability.everyone,
+    Seq.empty
   )
 
   val sampleDomainArticle = Article(
@@ -306,7 +312,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    Availability.everyone
+    Availability.everyone,
+    Seq.empty
   )
 
   val sampleDomainArticle2 = Article(
@@ -332,7 +339,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    Availability.everyone
+    Availability.everyone,
+    Seq.empty
   )
 
   val newArticle = api.NewArticle(
@@ -360,7 +368,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    availability = None
+    availability = None,
+    Seq.empty
   )
 
   val sampleArticleWithByNcSa = sampleArticleWithPublicDomain.copy(copyright = Some(byNcSaCopyright))
@@ -397,7 +406,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    Availability.everyone
+    Availability.everyone,
+    Seq.empty
   )
 
   val apiArticleWithHtmlFaultV2 = api.Article(
@@ -440,7 +450,8 @@ object TestData {
     Seq.empty,
     Seq.empty,
     Seq.empty,
-    availability = "everyone"
+    availability = "everyone",
+    Seq.empty
   )
 
   val (nodeId, nodeId2) = ("1234", "4321")

--- a/src/test/scala/no/ndla/draftapi/integration/ArticleApiClientTest.scala
+++ b/src/test/scala/no/ndla/draftapi/integration/ArticleApiClientTest.scala
@@ -65,7 +65,8 @@ class ArticleApiClientTest extends IntegrationSuite with UnitSuite with TestEnvi
     editorLabels = Seq.empty,
     grepCodes = Seq.empty,
     conceptIds = Seq.empty,
-    availability = Availability.everyone
+    availability = Availability.everyone,
+    relatedContent = Seq.empty
   )
 
   val exampleToken =

--- a/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -204,7 +204,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       editorLabels = Seq.empty,
       grepCodes = Seq.empty,
       conceptIds = Seq.empty,
-      availability = Availability.everyone
+      availability = Availability.everyone,
+      relatedContent = Seq.empty
     )
 
     val updatedNothing = TestData.blankUpdatedArticle.copy(
@@ -240,7 +241,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       editorLabels = Seq.empty,
       grepCodes = Seq.empty,
       conceptIds = Seq.empty,
-      availability = Availability.everyone
+      availability = Availability.everyone,
+      relatedContent = Seq.empty
     )
 
     val expectedArticle = Article(
@@ -266,7 +268,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       editorLabels = Seq.empty,
       grepCodes = Seq.empty,
       conceptIds = Seq.empty,
-      availability = Availability.everyone
+      availability = Availability.everyone,
+      relatedContent = Seq.empty
     )
 
     val updatedEverything = TestData.blankUpdatedArticle.copy(
@@ -320,7 +323,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       editorLabels = Seq.empty,
       grepCodes = Seq.empty,
       conceptIds = Seq.empty,
-      availability = Availability.everyone
+      availability = Availability.everyone,
+      relatedContent = Seq.empty
     )
 
     val expectedArticle = Article(
@@ -346,7 +350,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
       editorLabels = Seq.empty,
       grepCodes = Seq.empty,
       conceptIds = Seq.empty,
-      availability = Availability.everyone
+      availability = Availability.everyone,
+      relatedContent = Seq.empty
     )
 
     val updatedEverything = TestData.blankUpdatedArticle.copy(

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -806,4 +806,28 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       expectedPartialPublishFieldsLangALL)
   }
 
+  test("That updateArticle updates relatedContent") {
+    val apiRelatedContent1 = api.RelatedContentLink("url1", "title1")
+    val domainRelatedContent1 = domain.RelatedContentLink("url1", "title1")
+    val relatedContent2 = 2
+
+    val updatedApiArticle = TestData.blankUpdatedArticle.copy(
+      revision = 1,
+      relatedContent = Some(Seq(Left(apiRelatedContent1), Right(relatedContent2)))
+    )
+    val expectedArticle =
+      article.copy(revision = Some(article.revision.get + 1),
+                   relatedContent = Seq(Left(domainRelatedContent1), Right(relatedContent2)),
+                   updated = today)
+
+    service.updateArticle(articleId,
+                          updatedApiArticle,
+                          List.empty,
+                          Seq.empty,
+                          TestData.userWithWriteAccess,
+                          None,
+                          None,
+                          None) should equal(converterService.toApiArticle(expectedArticle, "en"))
+  }
+
 }


### PR DESCRIPTION
Relatert til NDLANO/Issues#2448

Se gjerne på https://github.com/NDLANO/article-api/pull/348 samtidig

Legger til et nytt felt i artikkel med relatert innhold. Dette skal på mange måter være likt som relaterte forklaringer som er en liste med id-er. Listen over relatert innhold skal også kunne innholde eksterne lenker (tittel+url).