### PR TITLE
2482 automatpublisering av partial publish fields

### DIFF
--- a/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -24,7 +24,7 @@ import org.json4s.{DefaultFormats, Formats}
 import org.scalatra.swagger.{ResponseMessage, Swagger}
 import org.scalatra.{Created, NotFound, Ok}
 
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
 trait DraftController {
   this: ReadService
@@ -514,7 +514,7 @@ trait DraftController {
         val oldNdlaUpdatedDate = paramOrNone("oldNdlaUpdatedDate").map(new DateTime(_).toDate)
         val importId = paramOrNone("importId")
         val id = long(this.articleId.paramName)
-        val updateArticle = extract[UpdatedArticle](request.body)
+        val updateArticle: Try[UpdatedArticle] = extract[UpdatedArticle](request.body)
 
         updateArticle.flatMap(
           writeService.updateArticle(id,

--- a/src/main/scala/no/ndla/draftapi/integration/ArticleApiClient.scala
+++ b/src/main/scala/no/ndla/draftapi/integration/ArticleApiClient.scala
@@ -27,6 +27,7 @@ case class PartialPublishArticle(availability: Option[domain.Availability.Value]
                                  grepCodes: Option[Seq[String]],
                                  license: Option[String],
                                  metaDescription: Option[Seq[domain.ArticleMetaDescription]],
+                                 relatedContent: Option[Seq[domain.RelatedContent]],
                                  tags: Option[Seq[domain.ArticleTag]])
 
 trait ArticleApiClient {

--- a/src/main/scala/no/ndla/draftapi/model/api/PartialPublishArticle.scala
+++ b/src/main/scala/no/ndla/draftapi/model/api/PartialPublishArticle.scala
@@ -13,7 +13,7 @@ import org.scalatra.swagger.annotations.{ApiModel, ApiModelProperty}
 import scala.annotation.meta.field
 
 object PartialArticleFields extends Enumeration {
-  val availability, grepCodes, license, metaDescription, tags = Value
+  val availability, grepCodes, license, metaDescription, relatedContent, tags = Value
 }
 
 // format: off

--- a/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -344,6 +344,7 @@ trait WriteService {
             grepCodes = Seq.empty,
             copyright = article.copyright.map(e => e.copy(license = None)),
             metaDescription = Seq.empty,
+            relatedContent = Seq.empty,
             tags = Seq.empty
         )
 
@@ -360,6 +361,7 @@ trait WriteService {
         e.grepCodes != changedArticle.grepCodes ||
         e.copyright.flatMap(e => e.license) != changedArticle.copyright.flatMap(e => e.license) ||
         e.metaDescription != changedArticle.metaDescription ||
+        e.relatedContent != changedArticle.relatedContent ||
         e.tags != changedArticle.tags
       })
 
@@ -657,7 +659,7 @@ trait WriteService {
                                    articleFieldsToUpdate: Seq[PartialArticleFields.Value],
                                    language: String): PartialPublishArticle = {
 
-      val initialPartial = PartialPublishArticle(None, None, None, None, None)
+      val initialPartial = PartialPublishArticle(None, None, None, None, None, None)
       articleFieldsToUpdate.distinct.foldLeft(initialPartial)((partialPublishArticle, field) => {
         field match {
           case PartialArticleFields.availability =>
@@ -671,6 +673,8 @@ trait WriteService {
           case PartialArticleFields.metaDescription =>
             partialPublishArticle.copy(
               metaDescription = Some(articleToPartialPublish.metaDescription.find(m => m.language == language).toSeq))
+          case PartialArticleFields.relatedContent =>
+            partialPublishArticle.copy(relatedContent = Some(articleToPartialPublish.relatedContent))
           case PartialArticleFields.tags if (language == Language.AllLanguages) =>
             partialPublishArticle.copy(tags = Some(articleToPartialPublish.tags))
           case PartialArticleFields.tags =>

--- a/src/test/scala/no/ndla/draftapi/TestData.scala
+++ b/src/test/scala/no/ndla/draftapi/TestData.scala
@@ -36,7 +36,7 @@ object TestData {
   val userWithPublishAccess = UserInfo("unit test", Set(Role.WRITE, Role.PUBLISH))
   val userWithAdminAccess = UserInfo("unit test", Set(Role.WRITE, Role.PUBLISH, Role.ADMIN))
 
-  private val publicDomainCopyright =
+  val publicDomainCopyright =
     Copyright(Some("publicdomain"), Some(""), List.empty, List(), List(), None, None, None)
   private val byNcSaCopyright = Copyright(Some(CC_BY_NC_SA.toString),
                                           Some("Gotham City"),

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -649,6 +649,109 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     result1.status.other.sorted should be(existing.status.other.map(_.toString).toSeq.sorted)
   }
 
+  test("article status should not be updated if any of the PartialArticleFields changes") {
+    val existingTitle = "tittel"
+    val updatedArticle = TestData.blankUpdatedArticle.copy(
+      revision = 1,
+      language = Some("nb"),
+      title = Some(existingTitle),
+      availability = Some(Availability.teacher.toString),
+      grepCodes = Some(Seq("a", "b", "c")),
+      copyright = Some(
+        api.Copyright(
+          license = Some(api.License("COPYRIGHTED", None, None)),
+          origin = None,
+          creators = Seq.empty,
+          processors = Seq.empty,
+          rightsholders = Seq.empty,
+          agreementId = None,
+          validFrom = None,
+          validTo = None
+        )),
+      metaDescription = Some("newMeta"),
+      tags = Some(Seq("new", "tag"))
+    )
+
+    val existing = TestData.sampleDomainArticle.copy(
+      title = Seq(ArticleTitle(existingTitle, "nb")),
+      status = TestData.statusWithPublished,
+      availability = Availability.everyone,
+      grepCodes = Seq.empty,
+      copyright = Some(TestData.publicDomainCopyright.copy(license = Some("oldLicense"), origin = None)),
+      metaDescription = Seq.empty,
+      tags = Seq.empty
+    )
+
+    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(writeService.partialPublish(any, any, any)).thenReturn((existing.id.get, Success(existing)))
+    when(articleApiClient.partialPublishArticle(any, any)).thenReturn(Success(existing.id.get))
+
+    val Success(result1) = service.updateArticle(existing.id.get,
+                                                 updatedArticle,
+                                                 List.empty,
+                                                 Seq.empty,
+                                                 TestData.userWithWriteAccess,
+                                                 None,
+                                                 None,
+                                                 None)
+
+    result1.status.current should be(existing.status.current.toString)
+    result1.status.other.sorted should be(existing.status.other.map(_.toString).toSeq.sorted)
+
+    result1.availability should be(Availability.teacher.toString)
+    result1.grepCodes should be(Seq("a", "b", "c"))
+    result1.copyright.get.license.get.license should be("COPYRIGHTED")
+    result1.metaDescription.get.metaDescription should be("newMeta")
+    result1.tags.get.tags should be(Seq("new", "tag"))
+  }
+
+  test("article status should change if any of the other fields changes") {
+    val existingTitle = "tittel"
+    val updatedArticle = TestData.blankUpdatedArticle.copy(
+      revision = 1,
+      language = Some("nb"),
+      title = Some(existingTitle),
+      copyright = Some(
+        api.Copyright(
+          license = Some(api.License("COPYRIGHTED", None, None)),
+          origin = Some("shouldCauseStatusChange"),
+          creators = Seq.empty,
+          processors = Seq.empty,
+          rightsholders = Seq.empty,
+          agreementId = None,
+          validFrom = None,
+          validTo = None
+        ))
+    )
+
+    val existing = TestData.sampleDomainArticle.copy(
+      title = Seq(ArticleTitle(existingTitle, "nb")),
+      status = TestData.statusWithPublished,
+      availability = Availability.everyone,
+      grepCodes = Seq.empty,
+      copyright = Some(TestData.publicDomainCopyright.copy(license = Some("oldLicense"), origin = None)),
+      metaDescription = Seq.empty,
+      tags = Seq.empty
+    )
+
+    when(draftRepository.withId(existing.id.get)).thenReturn(Some(existing))
+    when(writeService.partialPublish(any, any, any)).thenReturn((existing.id.get, Success(existing)))
+    when(articleApiClient.partialPublishArticle(any, any)).thenReturn(Success(existing.id.get))
+
+    val Success(result1) = service.updateArticle(existing.id.get,
+                                                 updatedArticle,
+                                                 List.empty,
+                                                 Seq.empty,
+                                                 TestData.userWithWriteAccess,
+                                                 None,
+                                                 None,
+                                                 None)
+
+    result1.status.current should not be (existing.status.current.toString)
+    result1.status.current should be(ArticleStatus.PROPOSAL.toString)
+    result1.status.other.sorted should not be (existing.status.other.map(_.toString).toSeq.sorted)
+  }
+
   test("Deleting storage should be called with correct path") {
     val imported = "https://api.ndla.no/files/194277/Temahefte%20egg%20og%20meieriprodukterNN.pdf"
     val notImported = "https://api.ndla.no/files/resources/01f6TKKF1wpAsc1Z.pdf"

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -270,30 +270,16 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       updated = today,
       published = yesterday,
       articleType = ArticleType.TopicArticle,
-      notes = Seq(
-        EditorNote(note = "Artikkelen har blitt delpublisert",
-                   user = "unit test",
-                   status = Status(current = ArticleStatus.DRAFT, other = Set.empty),
-                   timestamp = today))
     )
-    when(articleApiClient.partialPublishArticle(any, any)).thenReturn(Success(expectedArticle.id.get))
 
-    val result_with_fixed_timestamp = converterService
-      .toApiArticle(expectedArticle, "en")
-      .map(article => article.copy(notes = Seq(article.notes.head.copy(timestamp = today))))
-
-    val expected_with_fixed_timestamp = service
-      .updateArticle(articleId,
-                     updatedApiArticle,
-                     List.empty,
-                     Seq.empty,
-                     TestData.userWithWriteAccess,
-                     None,
-                     None,
-                     None)
-      .map(article => article.copy(notes = Seq(article.notes.head.copy(timestamp = today))))
-
-    expected_with_fixed_timestamp should equal(result_with_fixed_timestamp)
+    service.updateArticle(articleId,
+                          updatedApiArticle,
+                          List.empty,
+                          Seq.empty,
+                          TestData.userWithWriteAccess,
+                          None,
+                          None,
+                          None) should equal(converterService.toApiArticle(expectedArticle, "en"))
   }
 
   test("updateArticle should use user-defined status if defined") {

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -181,6 +181,9 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
                    content = Seq(ArticleContent(newContent, "en")),
                    updated = today)
 
+    when(writeService.partialPublish(any, any, any)).thenReturn((expectedArticle.id.get, Success(expectedArticle)))
+    when(articleApiClient.partialPublishArticle(any, any)).thenReturn(Success(expectedArticle.id.get))
+
     service.updateArticle(articleId,
                           updatedApiArticle,
                           List.empty,

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -672,6 +672,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
           validTo = None
         )),
       metaDescription = Some("newMeta"),
+      relatedContent = Some(Seq(Left(api.RelatedContentLink("title1", "url2")), Right(12L))),
       tags = Some(Seq("new", "tag"))
     )
 
@@ -682,6 +683,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       grepCodes = Seq.empty,
       copyright = Some(TestData.publicDomainCopyright.copy(license = Some("oldLicense"), origin = None)),
       metaDescription = Seq.empty,
+      relatedContent = Seq.empty,
       tags = Seq.empty
     )
 
@@ -705,6 +707,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     result1.grepCodes should be(Seq("a", "b", "c"))
     result1.copyright.get.license.get.license should be("COPYRIGHTED")
     result1.metaDescription.get.metaDescription should be("newMeta")
+    result1.relatedContent.head.leftSide should be(Left(api.RelatedContentLink("title1", "url2")))
+    result1.relatedContent.reverse.head should be(Right(12L))
     result1.tags.get.tags should be(Seq("new", "tag"))
     result1.notes.head.note should be("Artikkelen har blitt delpublisert")
   }
@@ -735,6 +739,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       grepCodes = Seq.empty,
       copyright = Some(TestData.publicDomainCopyright.copy(license = Some("oldLicense"), origin = None)),
       metaDescription = Seq.empty,
+      relatedContent = Seq.empty,
       tags = Seq.empty
     )
 
@@ -777,6 +782,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
           validTo = None
         )),
       metaDescription = Some("newMeta"),
+      relatedContent = Some(Seq(Left(api.RelatedContentLink("title1", "url2")), Right(12L))),
       tags = Some(Seq("new", "tag")),
       conceptIds = Some(Seq(1, 2, 3))
     )
@@ -788,6 +794,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       grepCodes = Seq.empty,
       copyright = Some(TestData.publicDomainCopyright.copy(license = Some("oldLicense"), origin = None)),
       metaDescription = Seq.empty,
+      relatedContent = Seq.empty,
       tags = Seq.empty,
       conceptIds = Seq.empty
     )
@@ -813,6 +820,8 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     result1.grepCodes should be(Seq("a", "b", "c"))
     result1.copyright.get.license.get.license should be("COPYRIGHTED")
     result1.metaDescription.get.metaDescription should be("newMeta")
+    result1.relatedContent.head.leftSide should be(Left(api.RelatedContentLink("title1", "url2")))
+    result1.relatedContent.reverse.head should be(Right(12L))
     result1.tags.get.tags should be(Seq("new", "tag"))
     result1.conceptIds should be(Seq(1, 2, 3))
     result1.notes.reverse.head.note should be("Artikkelen har blitt delpublisert")
@@ -923,6 +932,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
         ArticleMetaDescription("oldDesccc", "ru"),
         ArticleMetaDescription("oldDescccc", "nn")
       ),
+      relatedContent = Seq(Left(RelatedContentLink("title1", "url2")), Right(12L)),
       tags = Seq(ArticleTag(Seq("old", "tag"), "nb"),
                  ArticleTag(Seq("guten", "tag"), "de"),
                  ArticleTag(Seq("oldd", "tagg"), "es"))
@@ -933,6 +943,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       api.PartialArticleFields.grepCodes,
       api.PartialArticleFields.license,
       api.PartialArticleFields.metaDescription,
+      api.PartialArticleFields.relatedContent,
       api.PartialArticleFields.tags
     )
 
@@ -941,6 +952,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       grepCodes = Some(Seq("A", "B")),
       license = Some("CC-BY-4.0"),
       metaDescription = Some(Seq(ArticleMetaDescription("oldDesc", "nb"))),
+      relatedContent = Some(Seq(Left(RelatedContentLink("title1", "url2")), Right(12L))),
       tags = Some(Seq(ArticleTag(Seq("old", "tag"), "nb")))
     )
     val expectedPartialPublishFieldsLangEN = integration.PartialPublishArticle(
@@ -948,6 +960,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
       grepCodes = Some(Seq("A", "B")),
       license = Some("CC-BY-4.0"),
       metaDescription = Some(Seq.empty),
+      relatedContent = Some(Seq(Left(RelatedContentLink("title1", "url2")), Right(12L))),
       tags = Some(Seq.empty)
     )
     val expectedPartialPublishFieldsLangALL = integration.PartialPublishArticle(
@@ -961,6 +974,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
           ArticleMetaDescription("oldDesccc", "ru"),
           ArticleMetaDescription("oldDescccc", "nn")
         )),
+      relatedContent = Some(Seq(Left(RelatedContentLink("title1", "url2")), Right(12L))),
       tags = Some(
         Seq(ArticleTag(Seq("old", "tag"), "nb"),
             ArticleTag(Seq("guten", "tag"), "de"),


### PR DESCRIPTION
Fixes https://github.com/NDLANO/Issues/issues/2482

(availability, grepCodes, license, metaDescription, tags)-feltene blir automatisk publisert(sendt til article-api) ved lagring av artikkel. Oppdatering av disse feltene endrer ikke status på artikkelen.