### PR TITLE
Set json4s defaultformats withlong

### DIFF
--- a/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -37,7 +37,7 @@ trait DraftController {
   val draftController: DraftController
 
   class DraftController(implicit val swagger: Swagger) extends NdlaController {
-    protected implicit override val jsonFormats: Formats = DefaultFormats + new EnumNameSerializer(PartialArticleFields)
+    protected implicit override val jsonFormats: Formats = DefaultFormats.withLong + new EnumNameSerializer(PartialArticleFields)
     protected val applicationDescription = "API for accessing draft articles from ndla.no."
 
     // Additional models used in error responses

--- a/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
+++ b/src/main/scala/no/ndla/draftapi/controller/DraftController.scala
@@ -37,7 +37,8 @@ trait DraftController {
   val draftController: DraftController
 
   class DraftController(implicit val swagger: Swagger) extends NdlaController {
-    protected implicit override val jsonFormats: Formats = DefaultFormats.withLong + new EnumNameSerializer(PartialArticleFields)
+    protected implicit override val jsonFormats: Formats = DefaultFormats.withLong + new EnumNameSerializer(
+      PartialArticleFields)
     protected val applicationDescription = "API for accessing draft articles from ndla.no."
 
     // Additional models used in error responses

--- a/src/main/scala/no/ndla/draftapi/controller/NdlaController.scala
+++ b/src/main/scala/no/ndla/draftapi/controller/NdlaController.scala
@@ -46,7 +46,7 @@ import org.scalatra.util.NotNothing
 import scala.util.{Failure, Success, Try}
 
 abstract class NdlaController extends ScalatraServlet with NativeJsonSupport with LazyLogging with SwaggerSupport {
-  protected implicit override val jsonFormats: Formats = DefaultFormats
+  protected implicit override val jsonFormats: Formats = DefaultFormats.withLong
 
   before() {
     contentType = formats("json")

--- a/src/test/scala/no/ndla/draftapi/controller/DraftControllerTest.scala
+++ b/src/test/scala/no/ndla/draftapi/controller/DraftControllerTest.scala
@@ -419,5 +419,4 @@ class DraftControllerTest extends UnitSuite with TestEnvironment with ScalatraFu
     }
 
   }
-
 }

--- a/src/test/scala/no/ndla/draftapi/controller/NdlaControllerTest.scala
+++ b/src/test/scala/no/ndla/draftapi/controller/NdlaControllerTest.scala
@@ -1,0 +1,28 @@
+/*
+ * Part of NDLA draft_api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package no.ndla.draftapi.controller
+
+import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite}
+import no.ndla.draftapi.model.api.UpdatedArticle
+import org.scalatra.swagger.SwaggerEngine
+
+class NdlaControllerTest extends UnitSuite with TestEnvironment {
+
+  val ndlaController = new NdlaController {
+    override protected implicit def swagger: SwaggerEngine = ???
+
+    override protected def applicationDescription: String = ???
+  }
+
+  test("That extraction of request body parses relatedContent correctly") {
+    val updatedArticle = ndlaController.extract[UpdatedArticle]("""{"revision":2,"relatedContent":[1]}""").get
+
+    updatedArticle should be(TestData.blankUpdatedArticle.copy(revision = 2, relatedContent = Some(Seq(Right(1L)))))
+  }
+
+}

--- a/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -777,4 +777,18 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     res2.availability should be(Availability.everyone)
     res3.availability should be(Availability.everyone)
   }
+
+  test("toDomainArticle should convert relatedContent correctly") {
+
+    val Success(res1) =
+      service.toDomainArticle(1,
+                              TestData.sampleApiUpdateArticle.copy(relatedContent = Some(List(Right(1)))),
+                              isImported = false,
+                              TestData.userWithWriteAccess,
+                              None,
+                              None)
+
+    res1.relatedContent should be(List(Right(1L)))
+  }
+
 }


### PR DESCRIPTION
Hadde en bug med parsing av json som ikke ble plukket opp av testene. Tall i liste med relatert innhold ble parset som BigInt i stedet for Long og førte til at forespørsel ikke kunne håndteres. Dette er løst ved å sette `DefaultFormats.withLong`