### PR TITLE
Bugfix: relatedContent lese som BigInt og ikke Long

### DIFF
--- a/src/main/scala/no/ndla/draftapi/integration/ArticleApiClient.scala
+++ b/src/main/scala/no/ndla/draftapi/integration/ArticleApiClient.scala
@@ -38,7 +38,7 @@ trait ArticleApiClient {
     private val PublicEndpoint = s"http://$ApiGatewayHost/article-api/v2/articles"
     private val deleteTimeout = 1000 * 10 // 10 seconds
     private val timeout = 1000 * 15
-    private implicit val format: Formats = DefaultFormats + new EnumNameSerializer(domain.Availability)
+    private implicit val format: Formats = DefaultFormats.withLong + new EnumNameSerializer(domain.Availability)
 
     def partialPublishArticle(
         id: Long,

--- a/src/main/scala/no/ndla/draftapi/model/domain/Content.scala
+++ b/src/main/scala/no/ndla/draftapi/model/domain/Content.scala
@@ -56,7 +56,7 @@ case class Article(
 
 object Article extends SQLSyntaxSupport[Article] {
 
-  val jsonEncoder: Formats = DefaultFormats +
+  val jsonEncoder: Formats = DefaultFormats.withLong +
     new EnumNameSerializer(ArticleStatus) +
     new EnumNameSerializer(ArticleType) +
     new EnumNameSerializer(Availability)

--- a/src/test/scala/no/ndla/draftapi/integration/ArticleApiClientTest.scala
+++ b/src/test/scala/no/ndla/draftapi/integration/ArticleApiClientTest.scala
@@ -168,34 +168,4 @@ class ArticleApiClientTest extends IntegrationSuite with UnitSuite with TestEnvi
         result.isSuccess should be(true)
       }
   }
-
-  test("that updateArticle should parse relatedContent correctly") {
-    forgePact
-      .between("draft-api")
-      .and("article-api")
-      .addInteraction(
-        interaction
-          .description("Updating an article returns 200")
-          .given("articles")
-          .uponReceiving(method = POST,
-                         path = "/intern/article/1",
-                         query = None,
-                         headers = authHeaderMap,
-                         body = write(testArticle.copy(relatedContent = Seq(Right(2)))),
-                         matchingRules = None)
-          .willRespondWith(200)
-      )
-      .runConsumerTest { mockConfig =>
-        AuthUser.setHeader(s"Bearer $exampleToken")
-        val articleApiClient = new ArticleApiClient(mockConfig.baseUrl)
-        val updatedArticle = articleApiClient.updateArticle(1,
-                                                            testArticle.copy(relatedContent = Seq(Right(2))),
-                                                            List("1234"),
-                                                            false,
-                                                            false)
-        val Right(relatedId) = updatedArticle.get.relatedContent.head
-        relatedId.toLong should be(1L)
-
-      }
-  }
 }

--- a/src/test/scala/no/ndla/draftapi/repository/DraftRepositoryTest.scala
+++ b/src/test/scala/no/ndla/draftapi/repository/DraftRepositoryTest.scala
@@ -416,4 +416,12 @@ class DraftRepositoryTest extends IntegrationSuite(EnablePostgresContainer = tru
     grepCodes8.length should be(1)
     grepCodesCount8 should be(1)
   }
+
+  test("withId parse relatedContent correctly") {
+    repository.insert(sampleArticle.copy(id = Some(1), relatedContent = Seq(Right(2))))
+
+    val Right(relatedId) = repository.withId(1).get.relatedContent.head
+    relatedId.toLong should be(2L)
+
+  }
 }


### PR DESCRIPTION
Problemet med BigInt som dukker opp var visst ikke helt løst. Forrige bugfix (#257 ) gjorde det mulig å lagre tallverdier, men samme bug oppsto ved henting av artikkel. Har lagt inn DefaultFormats.withLong der også.

Er det flere ting som burde dobbeltsjekkes?

Se også article-api: https://github.com/NDLANO/article-api/pull/349

Edit: Jeg har nå også oppdatert article-api med withLong der det burde være nødvendig. Jeg klarte å fange opp en feil i article-api som jeg har skrevet test på.