### PR TITLE
Enforce sorted language fields when comparing objects.

### DIFF
--- a/src/main/scala/no/ndla/draftapi/model/domain/LanguageField.scala
+++ b/src/main/scala/no/ndla/draftapi/model/domain/LanguageField.scala
@@ -7,7 +7,8 @@
 
 package no.ndla.draftapi.model.domain
 
-trait LanguageField {
+trait LanguageField extends Ordered[LanguageField] {
+  def compare(that: LanguageField): Int = this.language.compare(that.language)
   def isEmpty: Boolean
   def language: String
 }

--- a/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -357,7 +357,13 @@ trait WriteService {
             copyright = article.copyright.map(e => e.copy(license = None)),
             metaDescription = Seq.empty,
             relatedContent = Seq.empty,
-            tags = Seq.empty
+            tags = Seq.empty,
+            // LanguageField ordering shouldn't matter:
+            visualElement = article.visualElement.sorted,
+            content = article.content.sorted,
+            introduction = article.introduction.sorted,
+            metaImage = article.metaImage.sorted,
+            title = article.title.sorted
         )
 
       val comparableNew = withComparableValues(changedArticle)

--- a/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -341,7 +341,7 @@ trait WriteService {
 
     /** Article status should not be updated if notes and/or editorLabels are the only changes */
     /** Update 2021: Nor should the status be updated if only any of PartialArticleFields.Value has changed */
-    private def shouldUpdateStatus(changedArticle: domain.Article, existingArticle: domain.Article): Boolean = {
+    def shouldUpdateStatus(changedArticle: domain.Article, existingArticle: domain.Article): Boolean = {
       // Function that sets values we don't want to include when comparing articles to check if we should update status
       val withComparableValues =
         (article: domain.Article) =>

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1114,4 +1114,17 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
   }
 
+  test("shouldUpdateStatus returns false if articles are equal") {
+    val nnTitle = ArticleTitle("Title", "nn")
+    val nbTitle = ArticleTitle("Title", "nb")
+
+    val article1 = TestData.sampleDomainArticle.copy(title = Seq(nnTitle, nbTitle))
+    val article2 = TestData.sampleDomainArticle.copy(title = Seq(nnTitle, nbTitle))
+    service.shouldUpdateStatus(article1, article2) should be(false)
+
+    val article3 = TestData.sampleDomainArticle.copy(title = Seq(nnTitle, nbTitle))
+    val article4 = TestData.sampleDomainArticle.copy(title = Seq(nbTitle, nnTitle))
+    service.shouldUpdateStatus(article3, article4) should be(true) // Should be false!
+  }
+
 }

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -1124,7 +1124,7 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
 
     val article3 = TestData.sampleDomainArticle.copy(title = Seq(nnTitle, nbTitle))
     val article4 = TestData.sampleDomainArticle.copy(title = Seq(nbTitle, nnTitle))
-    service.shouldUpdateStatus(article3, article4) should be(true) // Should be false!
+    service.shouldUpdateStatus(article3, article4) should be(false)
   }
 
 }


### PR DESCRIPTION
Sammenligning av språkversjoner burde være uavhengig av rekkefølge. Sjekken på om to artikler er like i WriteService shouldUpdateStatus må ta høgde for rekkefølgen på språkversjoner.