### PR TITLE
Sort fields before compare.

### DIFF
--- a/src/main/scala/no/ndla/draftapi/service/WriteService.scala
+++ b/src/main/scala/no/ndla/draftapi/service/WriteService.scala
@@ -372,8 +372,7 @@ trait WriteService {
       shouldUpdateStatus
     }
 
-    private def shouldPartialPublish(existingArticle: Option[domain.Article],
-                                     changedArticle: domain.Article): Boolean = {
+    def shouldPartialPublish(existingArticle: Option[domain.Article], changedArticle: domain.Article): Boolean = {
       val isPublished =
         changedArticle.status.current == ArticleStatus.PUBLISHED ||
           changedArticle.status.other.contains(ArticleStatus.PUBLISHED)
@@ -382,9 +381,9 @@ trait WriteService {
         e.availability != changedArticle.availability ||
         e.grepCodes != changedArticle.grepCodes ||
         e.copyright.flatMap(e => e.license) != changedArticle.copyright.flatMap(e => e.license) ||
-        e.metaDescription != changedArticle.metaDescription ||
+        e.metaDescription.sorted != changedArticle.metaDescription.sorted ||
         e.relatedContent != changedArticle.relatedContent ||
-        e.tags != changedArticle.tags
+        e.tags.sorted != changedArticle.tags.sorted
       })
 
       isPublished && hasChangedPartialPublishField

--- a/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/WriteServiceTest.scala
@@ -9,9 +9,9 @@ package no.ndla.draftapi.service
 
 import java.io.ByteArrayInputStream
 import java.util.Date
-
 import no.ndla.draftapi.auth.{Role, UserInfo}
 import no.ndla.draftapi.model.api.ArticleApiArticle
+import no.ndla.draftapi.model.domain.ArticleStatus.{DRAFT, PUBLISHED}
 import no.ndla.draftapi.model.{api, domain}
 import no.ndla.draftapi.model.domain._
 import no.ndla.draftapi.{TestData, TestEnvironment, UnitSuite, integration}
@@ -1125,6 +1125,24 @@ class WriteServiceTest extends UnitSuite with TestEnvironment {
     val article3 = TestData.sampleDomainArticle.copy(title = Seq(nnTitle, nbTitle))
     val article4 = TestData.sampleDomainArticle.copy(title = Seq(nbTitle, nnTitle))
     service.shouldUpdateStatus(article3, article4) should be(false)
+  }
+
+  test("shouldPartialPublish return false if articles are equal") {
+    val nnMeta = ArticleMetaDescription("Meta nn", "nn")
+    val nbMeta = ArticleMetaDescription("Meta nb", "nb")
+
+    val article1 = TestData.sampleDomainArticle.copy(status = domain.Status(DRAFT, Set(PUBLISHED)),
+                                                     metaDescription = Seq(nnMeta, nbMeta))
+    val article2 = TestData.sampleDomainArticle.copy(status = domain.Status(DRAFT, Set(PUBLISHED)),
+                                                     metaDescription = Seq(nnMeta, nbMeta))
+    service.shouldPartialPublish(Some(article1), article2) should be(false)
+
+    val article3 = TestData.sampleDomainArticle.copy(status = domain.Status(DRAFT, Set(PUBLISHED)),
+                                                     metaDescription = Seq(nnMeta, nbMeta))
+    val article4 = TestData.sampleDomainArticle.copy(status = domain.Status(DRAFT, Set(PUBLISHED)),
+                                                     metaDescription = Seq(nbMeta, nnMeta))
+    service.shouldPartialPublish(Some(article3), article4) should be(false)
+
   }
 
 }


### PR DESCRIPTION
Artikler delpubliseres uten at det er endringer. Det skyldes at rekkefølgen på felta har endra seg ved innsendng fra ed. Så har berre lagt inn sortering av språkhåndterte feil før sammenligning.