### PR TITLE
Changing set to LinkedHashSet to enforce order

### DIFF
--- a/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
+++ b/src/main/scala/no/ndla/draftapi/service/StateTransitionRules.scala
@@ -8,7 +8,6 @@
 package no.ndla.draftapi.service
 
 import java.util.Date
-
 import cats.effect.IO
 import no.ndla.draftapi.auth.UserInfo
 import no.ndla.draftapi.model.api.{IllegalStatusStateTransition, NotFoundException}
@@ -30,6 +29,7 @@ import no.ndla.draftapi.service.search.ArticleIndexService
 import no.ndla.draftapi.validation.ContentValidator
 import no.ndla.validation.{ValidationException, ValidationMessage}
 
+import scala.collection.mutable
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
@@ -96,7 +96,7 @@ trait StateTransitionRules {
     import StateTransition._
 
     // format: off
-    val StateTransitions: Set[StateTransition] = Set(
+    val StateTransitions: mutable.LinkedHashSet[StateTransition] = mutable.LinkedHashSet(
       (IMPORTED                      -> DRAFT)                         keepCurrentOnTransition,
        DRAFT                         -> DRAFT,
        DRAFT                         -> PROPOSAL,
@@ -182,7 +182,7 @@ trait StateTransitionRules {
        QUEUED_FOR_LANGUAGE           -> PROPOSAL,
        QUEUED_FOR_LANGUAGE           -> TRANSLATED,
        QUEUED_FOR_LANGUAGE           -> ARCHIVED                       require PublishRoles illegalStatuses Set(PUBLISHED),
-       QUEUED_FOR_LANGUAGE           -> AWAITING_ARCHIVING,
+       //QUEUED_FOR_LANGUAGE           -> AWAITING_ARCHIVING,
       (QUEUED_FOR_LANGUAGE           -> PUBLISHED)                     keepStates Set(IMPORTED) require PublishRoles withSideEffect publishArticle,
        TRANSLATED                    -> TRANSLATED,
        TRANSLATED                    -> PROPOSAL,

--- a/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
+++ b/src/test/scala/no/ndla/draftapi/service/ConverterServiceTest.scala
@@ -154,6 +154,8 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
     writeTrans(QUALITY_ASSURED.toString).length should be < adminTrans(QUALITY_ASSURED.toString).length
     writeTrans(QUALITY_ASSURED_DELAYED.toString).length should be < adminTrans(QUALITY_ASSURED_DELAYED.toString).length
     writeTrans(QUEUED_FOR_PUBLISHING.toString).length should be < adminTrans(QUEUED_FOR_PUBLISHING.toString).length
+    writeTrans(QUEUED_FOR_LANGUAGE.toString).length should be < adminTrans(QUEUED_FOR_LANGUAGE.toString).length
+    writeTrans(TRANSLATED.toString).length should be < adminTrans(TRANSLATED.toString).length
     writeTrans(QUEUED_FOR_PUBLISHING_DELAYED.toString).length should be < adminTrans(QUEUED_FOR_PUBLISHING_DELAYED.toString).length
     writeTrans(PUBLISHED.toString).length should be < adminTrans(PUBLISHED.toString).length
     writeTrans(AWAITING_UNPUBLISHING.toString).length should be < adminTrans(AWAITING_UNPUBLISHING.toString).length
@@ -164,6 +166,20 @@ class ConverterServiceTest extends UnitSuite with TestEnvironment {
   test("stateTransitionsToApi should have transitions from all statuses if admin") {
     val adminTrans = service.stateTransitionsToApi(TestData.userWithAdminAccess)
     adminTrans.size should be(ArticleStatus.values.size)
+  }
+
+  test("stateTransitionsToApi should have transitions in inserted order") {
+    val adminTrans = service.stateTransitionsToApi(TestData.userWithAdminAccess)
+    adminTrans(QUEUED_FOR_LANGUAGE.toString) should be(
+      Seq(QUEUED_FOR_LANGUAGE.toString, PROPOSAL.toString, TRANSLATED.toString, ARCHIVED.toString, PUBLISHED.toString))
+    adminTrans(TRANSLATED.toString) should be(
+      Seq(TRANSLATED.toString,
+          PROPOSAL.toString,
+          AWAITING_QUALITY_ASSURANCE.toString,
+          QUALITY_ASSURED.toString,
+          PUBLISHED.toString,
+          ARCHIVED.toString)
+    )
   }
 
   test("newNotes should fail if empty strings are recieved") {


### PR DESCRIPTION
Fixes NDLANO/Issues#2564

Endrer type på set for å tvinge samme rekkefølge i api som i definisjon.