### PR TITLE
#2665: Adds migration to convert `fullbredde` to `full` for images `data-size`

### DIFF
--- a/src/main/scala/db/migration/V32__FullbreddeImagesToFull.scala
+++ b/src/main/scala/db/migration/V32__FullbreddeImagesToFull.scala
@@ -1,0 +1,125 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2020 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import org.flywaydb.core.api.migration.{BaseJavaMigration, Context}
+import org.json4s
+import org.json4s.DefaultFormats
+import org.json4s.JsonAST.{JArray, JString}
+import org.json4s.native.JsonMethods.{compact, parse, render}
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Element
+import org.jsoup.nodes.Entities.EscapeMode
+import org.postgresql.util.PGobject
+import scalikejdbc.{DB, DBSession, _}
+
+class V32__FullbreddeImagesToFull extends BaseJavaMigration {
+  implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+
+  override def migrate(context: Context): Unit = {
+    val db = DB(context.getConnection)
+    db.autoClose(false)
+
+    db.withinTx { implicit session =>
+      migrateArticles
+    }
+  }
+
+  def migrateArticles(implicit session: DBSession): Unit = {
+    val count = countAllArticles.get
+    var numPagesLeft = (count / 1000) + 1
+    var offset = 0L
+
+    while (numPagesLeft > 0) {
+      allArticles(offset * 1000).map {
+        case (id, document) => updateArticle(convertArticleUpdate(document), id)
+      }
+      numPagesLeft -= 1
+      offset += 1
+    }
+  }
+
+  def countAllArticles(implicit session: DBSession): Option[Long] = {
+    sql"select count(*) from articledata where document is not NULL"
+      .map(rs => rs.long("count"))
+      .single()
+      .apply()
+  }
+
+  def allArticles(offset: Long)(implicit session: DBSession): Seq[(Long, String)] = {
+    sql"select id, document, article_id from articledata where document is not null order by id limit 1000 offset $offset"
+      .map(rs => {
+        (rs.long("id"), rs.string("document"))
+      })
+      .list()
+      .apply()
+  }
+
+  def updateArticle(document: String, id: Long)(implicit session: DBSession): Int = {
+    val dataObject = new PGobject()
+    dataObject.setType("jsonb")
+    dataObject.setValue(document)
+
+    sql"update articledata set document = $dataObject where id = $id"
+      .update()
+      .apply()
+  }
+
+  private def stringToJsoupDocument(htmlString: String): Element = {
+    val document = Jsoup.parseBodyFragment(htmlString)
+    document.outputSettings().escapeMode(EscapeMode.xhtml).prettyPrint(false)
+    document.select("body").first()
+  }
+
+  private def jsoupDocumentToString(element: Element): String = {
+    element.select("body").html()
+  }
+
+  def fixImageSizesInHtml(html: String): String = {
+    val doc = stringToJsoupDocument(html)
+    doc
+      .select("embed")
+      .forEach(embed => {
+        val dataResource = embed.attr("data-resource")
+        val isImage = dataResource == "image"
+        val hasSize = embed.hasAttr("data-size")
+
+        if (isImage && hasSize) {
+          val oldSize = embed.attr("data-size")
+          val newSize = oldSize.replace("fullbredde", "full")
+          embed.attr("data-size", newSize)
+        }
+
+      })
+    jsoupDocumentToString(doc)
+  }
+
+  def updateContent(contents: JArray, contentType: String): json4s.JValue = {
+    contents.map(content =>
+      content.mapField {
+        case (`contentType`, JString(html)) => (`contentType`, JString(fixImageSizesInHtml(html)))
+        case z                              => z
+    })
+  }
+
+  private[migration] def convertArticleUpdate(document: String): String = {
+    val oldArticle = parse(document)
+
+    val newArticle = oldArticle.mapField {
+      case ("content", contents: JArray) =>
+        val updatedContent = updateContent(contents, "content")
+        ("content", updatedContent)
+      case ("visualElement", visualElements: JArray) =>
+        val updatedVisualElement = updateContent(visualElements, "resource")
+        ("visualElement", updatedVisualElement)
+      case x => x
+    }
+
+    compact(render(newArticle))
+  }
+}

--- a/src/test/scala/db/migration/V32__FullbreddeImagesToFullTest.scala
+++ b/src/test/scala/db/migration/V32__FullbreddeImagesToFullTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Part of NDLA draft-api.
+ * Copyright (C) 2021 NDLA
+ *
+ * See LICENSE
+ */
+
+package db.migration
+
+import no.ndla.draftapi.{TestEnvironment, UnitSuite}
+
+import scala.util.Success
+
+class V32__FullbreddeImagesToFullTest extends UnitSuite with TestEnvironment {
+
+  test("Images in visualElement and content should be converted correctly") {
+
+    val beforeArticle =
+      """{"visualElement":[{"resource":"<embed data-size=\"fullbredde-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\">","language":"nb"},{"resource":"<embed data-size=\"fullbredde\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\">","language":"nn"}],"content":[{"content":"<section><embed data-size=\"fullbredde-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"><embed data-size=\"fullbredde\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"></section>","language":"nb"},{"content":"<section><embed data-size=\"fullbredde-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"><embed data-size=\"fullbredde\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"></section>","language":"nn"}]}"""
+    val expectedArticle =
+      """{"visualElement":[{"resource":"<embed data-size=\"full-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\">","language":"nb"},{"resource":"<embed data-size=\"full\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\">","language":"nn"}],"content":[{"content":"<section><embed data-size=\"full-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"><embed data-size=\"full\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"></section>","language":"nb"},{"content":"<section><embed data-size=\"full-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"><embed data-size=\"full\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"></section>","language":"nn"}]}"""
+
+    val migration = new V32__FullbreddeImagesToFull
+    migration.convertArticleUpdate(beforeArticle) should be(expectedArticle)
+  }
+
+  test("Already converted content should not be broken") {
+
+    val beforeArticle =
+      """{"visualElement":[{"resource":"<embed data-size=\"full-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\">","language":"nb"},{"resource":"<embed data-size=\"full\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\">","language":"nn"}],"content":[{"content":"<section><embed data-size=\"full-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"><embed data-size=\"full\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"></section>","language":"nb"},{"content":"<section><embed data-size=\"full-hide-byline\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"><embed data-size=\"full\" data-align=\"\" data-caption=\"\" data-alt=\"Ein ung mann sit på kanten av senga og støttar hovudet i den eine handa. Foto.\n\" data-resource_id=\"53386\" data-resource=\"image\"></section>","language":"nn"}]}"""
+
+    val migration = new V32__FullbreddeImagesToFull
+    migration.convertArticleUpdate(beforeArticle) should be(beforeArticle)
+  }
+}


### PR DESCRIPTION
NDLANO/Issues#2665
Depends on https://github.com/NDLANO/editorial-frontend/pull/1119

Kan testes ved å sjekke at bilder (i content og visualElement) blir migrert fra `fullbredde` til `full` i data-size.